### PR TITLE
Fix async and doc build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,80 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    # Run the tests in each of the feature combinations.
+    # This is not an exhaustive test of all possible combinations,
+    # just those that affect the code in the crate.
+    name: test (${{ matrix.features }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          # No features at all
+          - ""
+          # lua54+vendored base, then all combinations of: send, async, derive
+          - lua54,vendored
+          - lua54,vendored,send
+          - lua54,vendored,async
+          - lua54,vendored,derive
+          - lua54,vendored,send,async
+          - lua54,vendored,send,derive
+          - lua54,vendored,async,derive
+          - lua54,vendored,send,async,derive
+          # Full feature set including serialize and macros
+          - lua54,vendored,send,async,derive,serialize,macros
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Check
+        run: cargo check ${{ matrix.features && format('--features {0}', matrix.features) }}
+
+      - name: Test
+        env:
+          TEST_LUAU: ${{ contains(matrix.features, 'luau') && '1' || '' }}
+        # Note: we're not doing a full `cargo test` here because some doc comments
+        # implicitly rely on feature flags that may not be present in a given invocation
+        run: cargo test --lib --tests ${{ matrix.features && format('--features {0}', matrix.features) }}
+
+  docs:
+    # Test building the docs, and the doc comment code samples
+    name: docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      # Grab the features from the manifest so that we're not duplicating
+      # them here in this workflow.  This enables running the docs the
+      # same way that docs.rs will run them.
+      - name: Extract docs.rs features
+        id: docsrs
+        run: |
+          features=$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[]
+                      | select(.name == "mlua-extras")
+                      | .metadata.docs.rs.features
+                      | join(",")')
+          echo "features=$features" >> "$GITHUB_OUTPUT"
+
+      # Now build the docs with that set of features
+      - name: Build docs
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --no-deps --features "${{ steps.docsrs.outputs.features }}"
+
+      # And the doc comment inline code samples
+      - name: Doc tests
+        run: cargo test --doc --features "${{ steps.docsrs.outputs.features }}"

--- a/src/typed/class/mod.rs
+++ b/src/typed/class/mod.rs
@@ -1,4 +1,6 @@
 use mlua::{AnyUserData, FromLua, FromLuaMulti, IntoLua, IntoLuaMulti, Lua};
+#[cfg(feature = "async")]
+use mlua::{UserDataRef, UserDataRefMut};
 
 use crate::MaybeSend;
 
@@ -58,22 +60,22 @@ pub trait TypedDataMethods<T> {
 
     #[cfg(feature = "async")]
     ///exposes an async method to lua
-    fn add_async_method<'s, S: Into<String>, A, R, M, MR>(&mut self, name: S, method: M)
+    fn add_async_method<S: Into<String>, A, R, M, MR>(&mut self, name: S, method: M)
     where
         T: 'static,
-        M: Fn(&Lua, &'s T, A) -> MR + MaybeSend + 'static,
+        M: Fn(Lua, UserDataRef<T>, A) -> MR + MaybeSend + 'static,
         A: FromLuaMulti + TypedMultiValue,
-        MR: std::future::Future<Output = mlua::Result<R>> + 's,
+        MR: std::future::Future<Output = mlua::Result<R>> + MaybeSend + 'static,
         R: IntoLuaMulti + TypedMultiValue;
 
     #[cfg(feature = "async")]
     ///exposes an async method to lua
-    fn add_async_method_mut<'s, S: Into<String>, A, R, M, MR>(&mut self, name: S, method: M)
+    fn add_async_method_mut<S: Into<String>, A, R, M, MR>(&mut self, name: S, method: M)
     where
         T: 'static,
-        M: Fn(&Lua, &'s mut T, A) -> MR + MaybeSend + 'static,
+        M: Fn(Lua, UserDataRefMut<T>, A) -> MR + MaybeSend + 'static,
         A: FromLuaMulti + TypedMultiValue,
-        MR: std::future::Future<Output = mlua::Result<R>> + 's,
+        MR: std::future::Future<Output = mlua::Result<R>> + MaybeSend + 'static,
         R: IntoLuaMulti + TypedMultiValue;
 
     ///Exposes a function to lua (its a method that does not take Self)
@@ -99,8 +101,8 @@ pub trait TypedDataMethods<T> {
         S: Into<String>,
         A: FromLuaMulti + TypedMultiValue,
         R: IntoLuaMulti + TypedMultiValue,
-        F: 'static + MaybeSend + Fn(&Lua, A) -> FR,
-        FR: std::future::Future<Output = mlua::Result<R>>;
+        F: 'static + MaybeSend + Fn(Lua, A) -> FR,
+        FR: 'static + MaybeSend + std::future::Future<Output = mlua::Result<R>>;
 
     ///Exposes a meta method to lua [http://lua-users.org/wiki/MetatableEvents](http://lua-users.org/wiki/MetatableEvents)
     fn add_meta_method<A, R, M>(&mut self, meta: impl Into<String>, method: M)

--- a/src/typed/class/mod.rs
+++ b/src/typed/class/mod.rs
@@ -12,25 +12,25 @@ mod standard;
 pub use wrapped::WrappedBuilder;
 pub use standard::TypedClassBuilder;
 
-/// Typed variant of [`UserData`]
+/// Typed variant of [`mlua::UserData`]
 pub trait TypedUserData: Sized {
     /// Add documentation to the type itself
     #[allow(unused_variables)]
     fn add_documentation<F: TypedDataDocumentation<Self>>(docs: &mut F) {}
 
-    ///same as [UserData::add_methods].
+    ///same as [`mlua::UserData::add_methods`].
     ///Refer to its documentation on how to use it.
     ///
     ///only difference is that it takes a [TypedDataMethods],
-    ///which is the typed version of [UserDataMethods]
+    ///which is the typed version of [`mlua::UserDataMethods`]
     #[allow(unused_variables)]
     fn add_methods<T: TypedDataMethods<Self>>(methods: &mut T) {}
 
-    /// same as [UserData::add_fields].
+    /// same as [`mlua::UserData::add_fields`].
     /// Refer to its documentation on how to use it.
     ///
     /// only difference is that it takes a [TypedDataFields],
-    /// which is the typed version of [UserDataFields]
+    /// which is the typed version of [`mlua::UserDataFields`]
     #[allow(unused_variables)]
     fn add_fields<F: TypedDataFields<Self>>(fields: &mut F) {}
 }
@@ -40,7 +40,7 @@ pub trait TypedDataDocumentation<T: TypedUserData> {
     fn add(&mut self, doc: &str) -> &mut Self;
 }
 
-/// Typed variant of [`UserDataFields`]
+/// Typed variant of [`mlua::UserDataMethods`]
 pub trait TypedDataMethods<T> {
     /// Exposes a method to lua
     fn add_method<S, A, R, M>(&mut self, name: S, method: M)
@@ -146,7 +146,7 @@ pub trait TypedDataMethods<T> {
     fn ret<S: std::fmt::Display>(&mut self, doc: S) -> &mut Self;
 }
 
-/// Typed variant of [`UserDataMethods`]
+/// Typed variant of [`mlua::UserDataFields`]
 pub trait TypedDataFields<T> {
     ///Adds documentation to the next field that gets added
     fn document(&mut self, doc: &str) -> &mut Self;

--- a/src/typed/class/standard.rs
+++ b/src/typed/class/standard.rs
@@ -63,7 +63,7 @@ impl TypedClassBuilder {
     /// TypedClassBuilder::default()
     ///     .field("data1", Type::string() | Type::nil(), "doc comment goes last")
     ///     .field("data2", Type::array(Type::string()), ()) // Can also use `None` instead of `()`
-    ///     .field("message", Type::string(), foramt!("A message for {NAME}"))
+    ///     .field("message", Type::string(), format!("A message for {NAME}"));
     /// ```
     pub fn field(mut self, key: impl Into<Index>, ty: Type, doc: impl IntoDocComment) -> Self {
         self.fields.insert(key.into(), Field::new(ty, doc));
@@ -80,7 +80,7 @@ impl TypedClassBuilder {
     /// TypedClassBuilder::default()
     ///     .function::<String, ()>("greet", "Greet the given name")
     ///     // Can use `None` instead of `()` for specifying the doc comment
-    ///     .function::<String, ()>("hello", ())
+    ///     .function::<String, ()>("hello", ());
     /// ```
     pub fn function<Params, Returns>(
         mut self,
@@ -115,7 +115,7 @@ impl TypedClassBuilder {
     /// TypedClassBuilder::default()
     ///     .method::<String, ()>("greet", "Greet the given name")
     ///     // Can use `None` instead of `()` for specifying the doc comment
-    ///     .method::<String, ()>("hello", ())
+    ///     .method::<String, ()>("hello", ());
     /// ```
     pub fn method<Params, Returns>(
         mut self,
@@ -149,7 +149,7 @@ impl TypedClassBuilder {
     /// TypedClassBuilder::default()
     ///     .meta_field("data1", Type::string() | Type::nil(), "doc comment goes last")
     ///     .meta_field("data2", Type::array(Type::string()), ()) // Can also use `None` instead of `()`
-    ///     .meta_field("message", Type::string(), foramt!("A message for {NAME}"))
+    ///     .meta_field("message", Type::string(), format!("A message for {NAME}"));
     /// ```
     pub fn meta_field(mut self, key: impl Into<Index>, ty: Type, doc: impl IntoDocComment) -> Self {
         self.meta_fields.insert(key.into(), Field::new(ty, doc));
@@ -166,7 +166,7 @@ impl TypedClassBuilder {
     /// TypedClassBuilder::default()
     ///     .meta_function::<String, ()>("greet", "Greet the given name")
     ///     // Can use `None` instead of `()` for specifying the doc comment
-    ///     .meta_function::<String, ()>("hello", ())
+    ///     .meta_function::<String, ()>("hello", ());
     /// ```
     pub fn meta_function<Params, Returns>(
         mut self,
@@ -203,7 +203,7 @@ impl TypedClassBuilder {
     /// TypedClassBuilder::default()
     ///     .method::<String, ()>("greet", "Greet the given name")
     ///     // Can use `None` instead of `()` for specifying the doc comment
-    ///     .method::<String, ()>("hello", ())
+    ///     .method::<String, ()>("hello", ());
     /// ```
     pub fn meta_method<Params, Returns>(
         mut self,

--- a/src/typed/class/standard.rs
+++ b/src/typed/class/standard.rs
@@ -502,15 +502,15 @@ impl<T: TypedUserData> TypedDataMethods<T> for TypedClassBuilder {
     }
 
     #[cfg(feature = "async")]
-    fn add_async_method<'s, S: ?Sized + AsRef<str>, A, R, M, MR>(&mut self, name: S, _: M)
+    fn add_async_method<S: Into<String>, A, R, M, MR>(&mut self, name: S, _: M)
     where
         T: 'static,
-        M: Fn(&Lua, &'s T, A) -> MR + MaybeSend + 'static,
+        M: Fn(Lua, mlua::UserDataRef<T>, A) -> MR + MaybeSend + 'static,
         A: FromLuaMulti + TypedMultiValue,
-        MR: std::future::Future<Output = mlua::Result<R>> + 's,
+        MR: std::future::Future<Output = mlua::Result<R>> + MaybeSend + 'static,
         R: IntoLuaMulti + TypedMultiValue,
     {
-        let name: Cow<'static, str> = name.as_ref().to_string().into();
+        let name: Cow<'static, str> = name.into().into();
         self.methods.insert(
             name.into(),
             Func::new::<A, R>(
@@ -522,15 +522,15 @@ impl<T: TypedUserData> TypedDataMethods<T> for TypedClassBuilder {
     }
 
     #[cfg(feature = "async")]
-    fn add_async_method_mut<'s, S: ?Sized + AsRef<str>, A, R, M, MR>(&mut self, name: S, method: M)
+    fn add_async_method_mut<S: Into<String>, A, R, M, MR>(&mut self, name: S, _method: M)
     where
         T: 'static,
-        M: Fn(&Lua, &'s mut T, A) -> MR + MaybeSend + 'static,
+        M: Fn(Lua, mlua::UserDataRefMut<T>, A) -> MR + MaybeSend + 'static,
         A: FromLuaMulti + TypedMultiValue,
-        MR: std::future::Future<Output = mlua::Result<R>> + 's,
+        MR: std::future::Future<Output = mlua::Result<R>> + MaybeSend + 'static,
         R: IntoLuaMulti + TypedMultiValue,
     {
-        let name: Cow<'static, str> = name.as_ref().to_string().into();
+        let name: Cow<'static, str> = name.into().into();
         self.methods.insert(
             name.into(),
             Func::new::<A, R>(
@@ -577,15 +577,15 @@ impl<T: TypedUserData> TypedDataMethods<T> for TypedClassBuilder {
     }
 
     #[cfg(feature = "async")]
-    fn add_async_function<S: ?Sized, A, R, F, FR>(&mut self, name: S, _: F)
+    fn add_async_function<S, A, R, F, FR>(&mut self, name: S, _: F)
     where
-        S: AsRef<str>,
+        S: Into<String>,
         A: FromLuaMulti + TypedMultiValue,
         R: IntoLuaMulti + TypedMultiValue,
-        F: 'static + MaybeSend + Fn(&Lua, A) -> FR,
-        FR: std::future::Future<Output = mlua::Result<R>>,
+        F: 'static + MaybeSend + Fn(Lua, A) -> FR,
+        FR: 'static + MaybeSend + std::future::Future<Output = mlua::Result<R>>,
     {
-        let name: Cow<'static, str> = name.as_ref().to_string().into();
+        let name: Cow<'static, str> = name.into().into();
         self.functions.insert(
             name.into(),
             Func::new::<A, R>(

--- a/src/typed/class/wrapped.rs
+++ b/src/typed/class/wrapped.rs
@@ -10,7 +10,7 @@ use crate::MaybeSend;
 use super::{Typed, TypedDataFields, TypedDataMethods, TypedMultiValue};
 
 /// Wrapper around a [`UserDataFields`] and [`UserDataMethods`]
-/// to allow [`TypedUserData`] implementations to be used for [`UserData`]
+/// to allow [`TypedUserData`](super::TypedUserData) implementations to be used for [`mlua::UserData`]
 /// implementations
 pub struct WrappedBuilder<'ctx, U>(&'ctx mut U);
 impl<'ctx, U> WrappedBuilder<'ctx, U> {

--- a/src/typed/class/wrapped.rs
+++ b/src/typed/class/wrapped.rs
@@ -2,6 +2,8 @@ use mlua::{
     AnyUserData, FromLua, FromLuaMulti, IntoLua, IntoLuaMulti, Lua, UserData,
     UserDataFields, UserDataMethods,
 };
+#[cfg(feature = "async")]
+use mlua::{UserDataRef, UserDataRefMut};
 
 use crate::MaybeSend;
 
@@ -163,25 +165,25 @@ impl<'ctx, T: UserData, U: UserDataMethods<T>> TypedDataMethods<T> for WrappedBu
     }
 
     #[cfg(feature = "async")]
-    fn add_async_method<'s, S: ?Sized + AsRef<str>, A, R, M, MR>(&mut self, name: &S, method: M)
+    fn add_async_method<S: Into<String>, A, R, M, MR>(&mut self, name: S, method: M)
     where
         T: 'static,
-        M: Fn(&Lua, &'s T, A) -> MR + MaybeSend + 'static,
+        M: Fn(Lua, UserDataRef<T>, A) -> MR + MaybeSend + 'static,
         A: FromLuaMulti + TypedMultiValue,
-        MR: std::future::Future<Output = mlua::Result<R>> + 's,
-        R: IntoLuaMulti,
+        MR: std::future::Future<Output = mlua::Result<R>> + MaybeSend + 'static,
+        R: IntoLuaMulti + TypedMultiValue,
     {
         self.0.add_async_method(name, method)
     }
 
     #[cfg(feature = "async")]
-    fn add_async_method_mut<'s, S: ?Sized + AsRef<str>, A, R, M, MR>(&mut self, name: &S, method: M)
+    fn add_async_method_mut<S: Into<String>, A, R, M, MR>(&mut self, name: S, method: M)
     where
         T: 'static,
-        M: Fn(&Lua, &'s mut T, A) -> MR + MaybeSend + 'static,
+        M: Fn(Lua, UserDataRefMut<T>, A) -> MR + MaybeSend + 'static,
         A: FromLuaMulti + TypedMultiValue,
-        MR: std::future::Future<Output = mlua::Result<R>> + 's,
-        R: IntoLuaMulti,
+        MR: std::future::Future<Output = mlua::Result<R>> + MaybeSend + 'static,
+        R: IntoLuaMulti + TypedMultiValue,
     {
         self.0.add_async_method_mut(name, method)
     }
@@ -206,13 +208,13 @@ impl<'ctx, T: UserData, U: UserDataMethods<T>> TypedDataMethods<T> for WrappedBu
     }
 
     #[cfg(feature = "async")]
-    fn add_async_function<S: ?Sized, A, R, F, FR>(&mut self, name: &S, function: F)
+    fn add_async_function<S, A, R, F, FR>(&mut self, name: S, function: F)
     where
-        S: AsRef<str>,
+        S: Into<String>,
         A: FromLuaMulti + TypedMultiValue,
         R: IntoLuaMulti + TypedMultiValue,
-        F: 'static + MaybeSend + Fn(&Lua, A) -> FR,
-        FR: std::future::Future<Output = mlua::Result<R>>,
+        F: 'static + MaybeSend + Fn(Lua, A) -> FR,
+        FR: 'static + MaybeSend + std::future::Future<Output = mlua::Result<R>>,
     {
         self.0.add_async_function(name, function)
     }
@@ -233,5 +235,35 @@ impl<'ctx, T: UserData, U: UserDataMethods<T>> TypedDataMethods<T> for WrappedBu
         F: FnMut(&Lua, A) -> mlua::Result<R> + MaybeSend + 'static,
     {
         self.0.add_meta_function_mut(meta, function)
+    }
+}
+
+#[cfg(test)]
+#[cfg(all(feature = "async", feature = "derive"))]
+mod tests {
+    use super::*;
+    use crate as mlua_extras;
+    use crate::typed::TypedUserData;
+    use crate::{Typed, UserData};
+
+    #[derive(Clone, Typed, UserData)]
+    struct Counter {
+        value: i64,
+    }
+
+    impl TypedUserData for Counter {
+        fn add_methods<T: TypedDataMethods<Self>>(methods: &mut T) {
+            methods.add_async_method("get_value", |_lua, this, _: ()| async move {
+                Ok(this.value)
+            });
+        }
+    }
+
+    #[test]
+    fn test_add_async_method_compiles() {
+        let lua = Lua::new();
+        lua.globals()
+            .set("counter", Counter { value: 42 })
+            .unwrap();
     }
 }

--- a/src/typed/generator/mod.rs
+++ b/src/typed/generator/mod.rs
@@ -179,7 +179,7 @@ impl DefinitionBuilder {
     ///
     /// # Example
     /// ```
-    /// user mlua_extras::{typed::{Definitions, TypedUserData}, Typed, UserData};
+    /// use mlua_extras::{typed::{generator::{Definitions, Definition}, TypedUserData, TypedDataFields}, Typed, UserData};
     ///
     /// #[derive(UserData, Typed)]
     /// struct Example {
@@ -189,13 +189,13 @@ impl DefinitionBuilder {
     ///     fn add_documentation<F: mlua_extras::typed::TypedDataDocumentation<Self>>(docs: &mut F) {
     ///         docs.add("This is an example");
     ///     }
-    ///     
+    ///
     ///     fn add_fields<F: TypedDataFields<Self>>(fields: &mut F) {
     ///         fields
     ///             .document("Example field")
     ///             .add_field_method_get_set(
     ///                 "color",
-    ///                 |_lua, this| Ok(this.color),
+    ///                 |_lua, this| Ok(this.color.clone()),
     ///                 |_lua, this, clr: String| {
     ///                     this.color = clr;
     ///                     Ok(())
@@ -204,9 +204,11 @@ impl DefinitionBuilder {
     ///     }
     /// }
     ///
-    /// Definitions::generate("init")
-    ///     .register::<Example>("Example")
-    ///     .value::<Example>("example")
+    /// Definitions::start()
+    ///     .define("init", Definition::start()
+    ///         .register::<Example>("Example")
+    ///         .value::<Example>("example")
+    ///     )
     ///     .finish();
     /// ```
     ///

--- a/src/typed/mod.rs
+++ b/src/typed/mod.rs
@@ -289,7 +289,7 @@ pub enum Type {
     ///
     /// ```lua
     /// --- @type string
-    /// --- @type number 
+    /// --- @type number
     /// --- @type 0
     /// --- @type "literal"
     /// --- @type Example
@@ -354,7 +354,7 @@ pub enum Type {
     /// Represents a function with it's parameters and return types
     ///
     /// # Example
-    /// 
+    ///
     /// ```lua
     /// --- @type fun(self: any, name: string): string
     /// ```
@@ -383,7 +383,7 @@ pub enum Type {
     /// ```lua
     /// --- @class {name}
     /// --- @field name string
-    /// --- @field age integer 
+    /// --- @field age integer
     /// --- @field height number
     /// ```
     Class(Box<TypedClassBuilder>),
@@ -396,7 +396,7 @@ pub enum Type {
 /// ```
 /// use mlua_extras::typed::Type;
 ///
-/// Type::string() | Type::nil()
+/// Type::string() | Type::nil();
 /// ```
 impl<T: Into<Type>> std::ops::BitOr<T> for Type {
     type Output = Self;
@@ -449,7 +449,7 @@ impl Type {
     /// use mlua_extras::typed::Type;
     ///
     /// // This references the type named `Example`
-    /// Type::named("Example")
+    /// Type::named("Example");
     /// ```
     pub fn named(value: impl Into<Cow<'static, str>>) -> Self {
         Self::Single(value.into())
@@ -596,12 +596,12 @@ macro_rules! impl_type_literal {
                 fn into_lua_type_literal(self) -> String {
                     self.to_string()
                 }
-            } 
+            }
             impl IntoLuaTypeLiteral for &$lit {
                 fn into_lua_type_literal(self) -> String {
                     self.to_string()
                 }
-            } 
+            }
         )*
     };
 }


### PR DESCRIPTION
This PR includes three commits:

 * Fix the build when the async feature is enabled (Fixes: https://github.com/Tired-Fox/mlua-extras/issues/18)
 * Fix the docs build; a number of doc tests had drifted from the current state of the code
 * Add a github actions CI workflow to exercise the various feature combinations, and explicitly build the docs with the same features as docs.rs, which should help to keep the docs working online at docs.rs