### PR TITLE
add LuauDefinitionFileGenerator

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,17 +32,26 @@ jobs:
           - lua54,vendored,send,async,derive
           # Full feature set including serialize and macros
           - lua54,vendored,send,async,derive,serialize,macros
+          # Luau feature combinations
+          - luau,vendored
+          - luau,vendored,send,async,derive,serialize,macros
     steps:
       - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 
+      - name: Install luau-lsp
+        if: contains(matrix.features, 'luau')
+        run: |
+          curl -fsSL -o luau-lsp.zip https://github.com/JohnnyMorganz/luau-lsp/releases/latest/download/luau-lsp-linux-x86_64.zip
+          unzip luau-lsp.zip -d luau-lsp
+          chmod +x luau-lsp/luau-lsp
+          echo "$PWD/luau-lsp" >> "$GITHUB_PATH"
+
       - name: Check
         run: cargo check ${{ matrix.features && format('--features {0}', matrix.features) }}
 
       - name: Test
-        env:
-          TEST_LUAU: ${{ contains(matrix.features, 'luau') && '1' || '' }}
         # Note: we're not doing a full `cargo test` here because some doc comments
         # implicitly rely on feature flags that may not be present in a given invocation
         run: cargo test --lib --tests ${{ matrix.features && format('--features {0}', matrix.features) }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +241,7 @@ dependencies = [
  "mlua-extras-derive",
  "serde",
  "strum",
+ "tempfile",
 ]
 
 [[package]]
@@ -583,6 +590,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ derive = ["dep:mlua-extras-derive"]
 
 [dev-dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
+tempfile = "3"
 
 [dependencies]
 mlua-extras-derive = { path = "./mlua_extras_derive", version = "11.6.0", optional = true }

--- a/LUAU.md
+++ b/LUAU.md
@@ -1,0 +1,253 @@
+# Luau Definition File Generator
+
+mlua-extras can generate `.d.luau` definition files that provide type
+information to the Luau type checker and [luau-lsp](https://github.com/JohnnyMorganz/luau-lsp).
+These files use native Luau type syntax (`declare class`, `declare function`,
+`export type`, etc.) rather than the LuaLS `--- @` annotation style used by
+the existing `DefinitionFileGenerator`.
+
+## Quick start
+
+```rust
+use mlua_extras::typed::generator::{
+    Definition, Definitions, LuauDefinitionFileGenerator,
+};
+
+let definitions = Definitions::start()
+    .define("init", Definition::start()
+        .register::<MyType>("MyType")
+        .value::<MyType>("instance")
+        .param("name", "Person to greet")
+        .function::<String, ()>("greet", ())
+    )
+    .finish();
+
+let gen = LuauDefinitionFileGenerator::new(definitions);
+for (name, writer) in gen.iter() {
+    writer.write_file(format!("types/{name}")).unwrap();
+}
+```
+
+This produces a file like:
+
+```luau
+declare class MyType
+    name: string
+    function getName(self): string
+end
+
+declare instance: MyType
+
+declare function greet(name: string): ()
+```
+
+## Validating generated definitions
+
+The standalone `luau-analyze` CLI from the [Luau repo](https://github.com/luau-lang/luau)
+does **not** support loading custom definition files. Use
+[luau-lsp](https://github.com/JohnnyMorganz/luau-lsp) instead, which has a
+one-shot `analyze` subcommand:
+
+```bash
+# Install luau-lsp (Linux x86_64 example)
+curl -L -o luau-lsp.zip \
+  https://github.com/JohnnyMorganz/luau-lsp/releases/latest/download/luau-lsp-linux-x86_64.zip
+unzip luau-lsp.zip && chmod +x luau-lsp
+
+# Type-check a script against your generated definitions
+luau-lsp analyze --defs=@myapp=types/init.d.luau my_script.luau
+```
+
+The `@myapp=` prefix is an arbitrary namespace label. Multiple `--defs` flags
+can be passed to load several definition files.
+
+## Luau definition file syntax
+
+The Luau [grammar page](https://luau.org/grammar) documents the language
+syntax but omits the `declare` keyword family used in definition files. This
+syntax is parsed by the Luau frontend but is only meaningful when loaded
+through the definition file API (as luau-lsp does with `--defs`). The
+standalone `luau-analyze` CLI treats `declare` statements as syntax errors
+when encountered in regular source files.
+
+### `declare class`
+
+Declares a named class type with fields and methods:
+
+```luau
+declare class Player
+    name: string
+    score: integer
+    function getName(self): string
+    function addScore(self, amount: integer): ()
+end
+```
+
+Every `function` inside a `declare class` block **must** list `self` as its
+first parameter (unannotated — no `: Type` after it). There is no way to
+declare a static or class-level function inside the class body. See
+[Impedance mismatches](#impedance-mismatches) below for how this affects the
+generator.
+
+Inheritance is supported:
+
+```luau
+declare class Animal
+    name: string
+end
+
+declare class Dog extends Animal
+    breed: string
+end
+```
+
+(The mlua-extras `Type` model does not currently support `extends`.)
+
+### `export type`
+
+Declares a named type alias visible to consumers of the definition file.
+Without `export`, type aliases are file-local and not usable by scripts that
+load the definitions.
+
+```luau
+export type Color = "Red" | "Green" | "Blue"
+export type StringOrNum = string | number
+export type Callback = (name: string) -> boolean
+```
+
+### `declare function`
+
+Declares a global function:
+
+```luau
+declare function greet(name: string): ()
+declare function parse(input: string): (boolean, string)
+```
+
+### `declare` (global variable)
+
+Declares a global variable with a type:
+
+```luau
+declare myGlobal: string
+declare config: { host: string, port: integer }
+```
+
+### Type syntax differences from LuaLS
+
+| Concept | LuaLS | Luau |
+|---|---|---|
+| Function type | `fun(a: T): R` | `(a: T) -> R` |
+| Array type | `T[]` | `{T}` |
+| Map type | `{ [K]: V }` | `{[K]: V}` |
+| Optional | `T \| nil` | `T?` (sugar) |
+| Intersection | not supported | `A & B` |
+
+## Impedance mismatches
+
+The following are known precision losses when mapping the mlua-extras `Type`
+model to Luau's type system. Each is covered by a test in
+`src/typed/generator/luau_type_file_tests.rs`.
+
+### `Variadic<T>` erases to `any`
+
+Rust's `Variadic<String>` maps to `Type::any()`, producing `...: any` in the
+definition file. The inner type is lost. A function declared as
+`fn(String, Variadic<i64>)` generates:
+
+```luau
+declare function log(param0: string, param1: any): ()
+```
+
+Ideally this would be `...: string` but the `Type` model does not yet support
+typed variadics or type packs.
+
+### Static functions use a separate global table
+
+Luau's `declare class` requires every `function` to have `self` as its first
+parameter, so there is no way to express a true static function inside the
+class body. The generator emits static functions (registered via
+`add_function`) as a separate `declare ClassName: { ... }` global table:
+
+```luau
+declare class Factory
+end
+
+declare Factory: {
+    create: (name: string) -> integer,
+}
+```
+
+This allows consumers to call `Factory.create("x")` without a spurious
+`self` parameter. The class declaration provides the type, and the global
+table declaration provides the static function bindings. Both coexist on the
+same name.
+
+### Heterogeneous tuples lose positional typing
+
+Luau has no tuple type syntax. A Rust tuple like `(String, i64, bool)` becomes
+an array whose element type is the union of all members:
+
+```luau
+export type Record = { string | integer | boolean }
+```
+
+This allows any element type at any position. Homogeneous tuples like
+`(i64, i64, i64)` correctly collapse to `{ integer }`.
+
+### `integer` and `number` are distinct
+
+Luau treats `integer` and `number` as incompatible types in definition files.
+Assigning an `integer`-typed value to a `number`-annotated variable (or vice
+versa) is a type error:
+
+```luau
+declare class Stats
+    count: integer
+    ratio: number
+end
+```
+
+```luau
+-- This is a type error in luau-lsp:
+local n: number = stats.count
+```
+
+The mlua-extras model maps Rust integer types (`i32`, `u64`, etc.) to
+`integer` and float types (`f32`, `f64`) to `number`, which is faithful to
+Luau's type system but may surprise users who expect them to be
+interchangeable.
+
+### Enum tuple variants flatten
+
+Rust enum variants that carry tuple data lose their structure. A variant like
+`Color::Rgb(u8, u8, u8)` becomes `{ integer }` — an array type with no arity
+constraint. An enum with mixed variant shapes:
+
+```rust
+Type::r#enum([
+    Type::literal("None"),
+    Type::tuple([Type::integer(), Type::string()]),
+    Type::tuple([Type::boolean()]),
+])
+```
+
+generates:
+
+```luau
+export type Payload = "None" | { integer | string } | { boolean }
+```
+
+The distinction between a 2-element `(integer, string)` variant and a
+3-element variant of the same types is lost.
+
+### Features not yet in the `Type` model
+
+The following Luau type system features cannot be expressed with the current
+mlua-extras `Type` enum and would require model changes to support:
+
+- **Generics** — `declare function clone<T>(value: T): T`
+- **Type packs** — `declare function pcall<A..., R...>(f: (A...) -> R..., ...: A...): (boolean, R...)`
+- **Class inheritance** — `declare class Dog extends Animal`
+- **Intersection types** — `((string) -> number) & ((number) -> string)`
+- **Read/write property modifiers** — `read name: string`

--- a/README.md
+++ b/README.md
@@ -240,3 +240,26 @@ function greet(name) end
 --- @param param0 Color
 function printColor(param0) end
 ```
+
+## Testing
+
+To run all the tests in one shot, use `cargo test --features luau,vendored,send,async,serialize,derive`
+
+Some features of this crate generate luau compatible definition files, or use
+luau specific features.  To add an additional layer of validation to the tests
+you can install [luau-lsp](https://github.com/JohnnyMorganz/luau-lsp) and
+the tests will run the type checker, and fail if the results are not as
+expected.
+
+See [our luau docs](LUAU.md#validating-generated-definitions) for more
+information on installing the lsp; there are pre-built binaries available
+which makes it quick and painless.
+
+The `TEST_LUAU` environment variable controls luau-lsp validation:
+
+| Value | Behavior |
+|---|---|
+| *(unset)* | Auto-detect `luau-lsp` on `PATH`. If found, run validation; otherwise skip. |
+| `0` | Skip validation entirely, even if `luau-lsp` is on `PATH`. |
+| *path* | Use the given value as the `luau-lsp` binary path (e.g. `TEST_LUAU=/tmp/luau-lsp`). |
+

--- a/examples/typed.rs
+++ b/examples/typed.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use mlua_extras::{
     Typed, UserData, extras::LuaExtras, mlua::{self, FromLua, Lua, LuaSerdeExt, MetaMethod, Value, Variadic}, typed::{
-        Type, TypedDataFields, TypedDataMethods, TypedUserData, generator::{Definition, DefinitionFileGenerator, Definitions}
+        Type, TypedDataFields, TypedDataMethods, TypedUserData, generator::{Definition, DefinitionFileGenerator, Definitions, LuauDefinitionFileGenerator}
     }
 };
 use serde::Deserialize;
@@ -161,7 +161,7 @@ fn main() -> mlua::Result<()> {
 
     // ===== Generate Types and Definition Files =====
 
-    let definitions = Definitions::start()
+    let definitions: Definitions = Definitions::start()
         .define("init", Definition::start()
             .register::<SystemColor>("System")
             .register::<Color>("Color")
@@ -179,8 +179,14 @@ fn main() -> mlua::Result<()> {
         std::fs::create_dir_all(&types_path).unwrap();
     }
 
-    let gen = DefinitionFileGenerator::new(definitions);
+    let gen = DefinitionFileGenerator::new(definitions.clone());
     for (name, writer) in gen.iter() {
+        println!("==== Generated \x1b[1;33mexample/types/{name}\x1b[0m ====");
+        writer.write_file(types_path.join(name)).unwrap();
+    }
+
+    let luau_gen = LuauDefinitionFileGenerator::new(definitions);
+    for (name, writer) in luau_gen.iter() {
         println!("==== Generated \x1b[1;33mexample/types/{name}\x1b[0m ====");
         writer.write_file(types_path.join(name)).unwrap();
     }

--- a/examples/types/init.d.luau
+++ b/examples/types/init.d.luau
@@ -1,0 +1,23 @@
+export type System = "Black" | "Red" | "Green" | "Yellow" | "Blue" | "Cyan" | "Magenta" | "White"
+
+export type Color = System | integer | { integer }
+
+-- This is a doc comment section for the overall type
+declare class Example
+	-- Example complex type
+	color: Color
+	function __tostring(self): string
+end
+
+declare Example: {
+	-- Log a specific format with any lua types
+	LogAny: (format: string, ...: any) -> (),
+	-- print all items
+	printAll: (...: any) -> (),
+}
+
+declare example: Example
+
+declare function greet(name: string): ()
+
+declare function printColor(color: Color): ()

--- a/src/typed/generator/luau_type_file.rs
+++ b/src/typed/generator/luau_type_file.rs
@@ -1,0 +1,424 @@
+use std::{cell::RefCell, collections::HashMap, path::Path, slice::Iter};
+
+use crate::typed::{function::Return, Param, Type};
+
+use super::{Definition, Definitions};
+
+/// Generates Luau definition files (`.d.luau`) for each
+/// [`Definition`][`crate::typed::generator::Definition`].
+///
+/// Each file uses native Luau type syntax: `declare class`, `declare function`,
+/// `type` aliases, and `declare` for global values. These files are consumed by
+/// the Luau type checker and by luau-lsp.
+///
+/// # Example Output
+///
+/// ```luau
+/// -- Example class
+/// declare class Example
+///     name: string
+///     function run(self): boolean
+/// end
+///
+/// declare example: Example
+/// ```
+pub struct LuauDefinitionFileGenerator {
+    extension: String,
+    definitions: Definitions,
+}
+
+impl Default for LuauDefinitionFileGenerator {
+    fn default() -> Self {
+        Self {
+            extension: ".d.luau".into(),
+            definitions: Definitions::default(),
+        }
+    }
+}
+
+impl LuauDefinitionFileGenerator {
+    pub fn new(definitions: Definitions) -> Self {
+        Self {
+            definitions,
+            ..Default::default()
+        }
+    }
+
+    pub fn ext(mut self, ext: impl AsRef<str>) -> Self {
+        self.extension = ext.as_ref().to_string();
+        self
+    }
+
+    pub fn iter(&self) -> LuauDefinitionFileIter<'_> {
+        LuauDefinitionFileIter {
+            extension: self.extension.clone(),
+            definitions: self.definitions.iter(),
+        }
+    }
+}
+
+pub struct LuauDefinitionFileIter<'def> {
+    extension: String,
+    definitions: Iter<'def, (String, Definition)>,
+}
+
+impl<'def> Iterator for LuauDefinitionFileIter<'def> {
+    type Item = (String, LuauDefinitionWriter<'def>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.definitions.next().map(|v| {
+            (
+                format!("{}{}", v.0, self.extension),
+                LuauDefinitionWriter {
+                    definition: &v.1,
+                    name_map: RefCell::new(HashMap::default()),
+                },
+            )
+        })
+    }
+}
+
+pub struct LuauDefinitionWriter<'def> {
+    definition: &'def Definition,
+    name_map: RefCell<HashMap<Type, String>>,
+}
+
+impl<'writer> LuauDefinitionWriter<'writer> {
+    pub fn write_file<P: AsRef<Path>>(self, path: P) -> mlua::Result<()> {
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(path)?;
+        self.write(&mut file)
+    }
+
+    pub fn write<W: std::io::Write>(self, mut buffer: W) -> mlua::Result<()> {
+        let mut first = true;
+
+        for definition in self.definition.iter() {
+            if !first {
+                writeln!(buffer)?;
+            }
+            first = false;
+
+            match &definition.ty {
+                Type::Value(ty) => {
+                    self.write_doc_comments(&mut buffer, &[definition.doc.as_deref()], "")?;
+                    writeln!(
+                        buffer,
+                        "declare {}: {}",
+                        definition.name,
+                        self.type_signature(ty)?
+                    )?;
+                }
+                Type::Class(type_data) => {
+                    self.name_map
+                        .borrow_mut()
+                        .insert(definition.ty.clone(), definition.name.clone());
+
+                    self.write_doc_comments(
+                        &mut buffer,
+                        &[definition.doc.as_deref(), type_data.type_doc.as_deref()],
+                        "",
+                    )?;
+                    writeln!(buffer, "declare class {}", definition.name)?;
+
+                    // Static fields
+                    for (name, field) in type_data.static_fields.iter() {
+                        self.write_doc_comments(
+                            &mut buffer,
+                            &[field.doc.as_deref()],
+                            "\t",
+                        )?;
+                        writeln!(buffer, "\t{}: {}", name, self.type_signature(&field.ty)?)?;
+                    }
+
+                    // Instance fields
+                    for (name, field) in type_data.fields.iter() {
+                        self.write_doc_comments(
+                            &mut buffer,
+                            &[field.doc.as_deref()],
+                            "\t",
+                        )?;
+                        writeln!(buffer, "\t{}: {}", name, self.type_signature(&field.ty)?)?;
+                    }
+
+                    // Methods (with self)
+                    for (name, func) in type_data.methods.iter() {
+                        self.write_doc_comments(
+                            &mut buffer,
+                            &[func.doc.as_deref()],
+                            "\t",
+                        )?;
+                        writeln!(
+                            buffer,
+                            "\tfunction {}(self{}{}): {}",
+                            name,
+                            if func.params.is_empty() { "" } else { ", " },
+                            self.param_list(&func.params)?,
+                            self.return_type(&func.returns)?,
+                        )?;
+                    }
+
+                    // Meta fields
+                    for (name, field) in type_data.meta_fields.iter() {
+                        self.write_doc_comments(
+                            &mut buffer,
+                            &[field.doc.as_deref()],
+                            "\t",
+                        )?;
+                        writeln!(buffer, "\t{}: {}", name, self.type_signature(&field.ty)?)?;
+                    }
+
+                    // Meta methods (with self)
+                    for (name, func) in type_data.meta_methods.iter() {
+                        self.write_doc_comments(
+                            &mut buffer,
+                            &[func.doc.as_deref()],
+                            "\t",
+                        )?;
+                        writeln!(
+                            buffer,
+                            "\tfunction {}(self{}{}): {}",
+                            name,
+                            if func.params.is_empty() { "" } else { ", " },
+                            self.param_list(&func.params)?,
+                            self.return_type(&func.returns)?,
+                        )?;
+                    }
+
+                    writeln!(buffer, "end")?;
+
+                    // Static functions and meta_functions are emitted as a
+                    // separate global table declaration, since `declare class`
+                    // requires `self` on every function.
+                    let static_fns: Vec<_> = type_data.functions.iter()
+                        .chain(type_data.meta_functions.iter())
+                        .collect();
+                    if !static_fns.is_empty() {
+                        writeln!(buffer)?;
+                        writeln!(buffer, "declare {}: {{", definition.name)?;
+                        for (name, func) in &static_fns {
+                            self.write_doc_comments(
+                                &mut buffer,
+                                &[func.doc.as_deref()],
+                                "\t",
+                            )?;
+                            writeln!(
+                                buffer,
+                                "\t{}: ({}) -> {},",
+                                name,
+                                self.param_list(&func.params)?,
+                                self.return_type(&func.returns)?,
+                            )?;
+                        }
+                        writeln!(buffer, "}}")?;
+                    }
+                }
+                Type::Enum(types) => {
+                    self.name_map
+                        .borrow_mut()
+                        .insert(definition.ty.clone(), definition.name.clone());
+
+                    self.write_doc_comments(
+                        &mut buffer,
+                        &[definition.doc.as_deref()],
+                        "",
+                    )?;
+                    let type_strs = types
+                        .iter()
+                        .map(|v| self.type_signature(v))
+                        .collect::<mlua::Result<Vec<_>>>()?;
+                    writeln!(
+                        buffer,
+                        "export type {} = {}",
+                        definition.name,
+                        type_strs.join(" | "),
+                    )?;
+                }
+                Type::Alias(ty) => {
+                    self.write_doc_comments(
+                        &mut buffer,
+                        &[definition.doc.as_deref()],
+                        "",
+                    )?;
+                    writeln!(
+                        buffer,
+                        "export type {} = {}",
+                        definition.name,
+                        self.type_signature(ty)?,
+                    )?;
+                }
+                Type::Function { params, returns } => {
+                    self.write_doc_comments(
+                        &mut buffer,
+                        &[definition.doc.as_deref()],
+                        "",
+                    )?;
+                    writeln!(
+                        buffer,
+                        "declare function {}({}): {}",
+                        definition.name,
+                        self.param_list(params)?,
+                        self.return_type(returns)?,
+                    )?;
+                }
+                other => {
+                    return Err(mlua::Error::runtime(format!(
+                        "invalid root level type: {:?}",
+                        other
+                    )))
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn type_signature(&self, ty: &Type) -> mlua::Result<String> {
+        Ok(match ty {
+            Type::Enum(_) => match self.name_map.borrow().get(ty) {
+                Some(name) => name.to_string(),
+                None => {
+                    return Err(mlua::Error::runtime(
+                        "missing enum type definition; make sure the type is registered before it is used",
+                    ))
+                }
+            },
+            Type::Class(_) => match self.name_map.borrow().get(ty) {
+                Some(name) => name.to_string(),
+                None => {
+                    return Err(mlua::Error::runtime(
+                        "missing class type definition; make sure the type is registered before it is used",
+                    ))
+                }
+            },
+            Type::Single(value) => value.to_string(),
+            Type::Tuple(types) => {
+                // Luau doesn't support integer literal keys in table types.
+                // If all element types are the same, emit as {T}.
+                // Otherwise emit as a union of the element types, which is
+                // the closest approximation without generics/type packs.
+                if types.is_empty() {
+                    "{}".to_string()
+                } else if types.iter().all(|t| t == &types[0]) {
+                    format!("{{ {} }}", self.type_signature(&types[0])?)
+                } else {
+                    // Collect unique types and emit as {T1 | T2 | ...}
+                    let mut seen = Vec::new();
+                    for t in types {
+                        if !seen.contains(t) {
+                            seen.push(t.clone());
+                        }
+                    }
+                    let sigs = seen
+                        .iter()
+                        .map(|v| self.type_signature(v))
+                        .collect::<mlua::Result<Vec<_>>>()?;
+                    format!("{{ {} }}", sigs.join(" | "))
+                }
+            }
+            Type::Array(ty) => {
+                format!("{{ {} }}", self.type_signature(ty)?)
+            }
+            Type::Map(key, value) => {
+                format!(
+                    "{{ [{}]: {} }}",
+                    self.type_signature(key)?,
+                    self.type_signature(value)?
+                )
+            }
+            Type::Function { params, returns } => {
+                format!(
+                    "({}) -> {}",
+                    self.param_list(params)?,
+                    self.return_type(returns)?,
+                )
+            }
+            Type::Union(types) => {
+                // Check for T | nil pattern and emit T? shorthand
+                if types.len() == 2 {
+                    let nil_pos = types.iter().position(|t| matches!(t, Type::Single(s) if s == "nil"));
+                    if let Some(pos) = nil_pos {
+                        let other = &types[1 - pos];
+                        let sig = self.type_signature(other)?;
+                        // Wrap complex types in parens before adding ?
+                        return Ok(if needs_parens_for_optional(other) {
+                            format!("({sig})?")
+                        } else {
+                            format!("{sig}?")
+                        });
+                    }
+                }
+                types
+                    .iter()
+                    .map(|v| self.type_signature(v))
+                    .collect::<mlua::Result<Vec<_>>>()?
+                    .join(" | ")
+            }
+            Type::Table(entries) => {
+                let fields = entries
+                    .iter()
+                    .map(|(k, v)| Ok(format!("{k}: {}", self.type_signature(v)?)))
+                    .collect::<mlua::Result<Vec<_>>>()?;
+                format!("{{ {} }}", fields.join(", "))
+            }
+            other => {
+                return Err(mlua::Error::runtime(format!(
+                    "type cannot be a type signature: {}",
+                    other.as_ref()
+                )))
+            }
+        })
+    }
+
+    fn param_list(&self, params: &[Param]) -> mlua::Result<String> {
+        params
+            .iter()
+            .enumerate()
+            .map(|(i, p)| {
+                let name = p
+                    .name
+                    .as_deref()
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| format!("param{i}"));
+                Ok(format!("{}: {}", name, self.type_signature(&p.ty)?))
+            })
+            .collect::<mlua::Result<Vec<_>>>()
+            .map(|v| v.join(", "))
+    }
+
+    fn return_type(&self, returns: &[Return]) -> mlua::Result<String> {
+        if returns.is_empty() {
+            return Ok("()".to_string());
+        }
+        let sigs = returns
+            .iter()
+            .map(|r| self.type_signature(&r.ty))
+            .collect::<mlua::Result<Vec<_>>>()?;
+        if sigs.len() == 1 {
+            Ok(sigs.into_iter().next().unwrap())
+        } else {
+            Ok(format!("({})", sigs.join(", ")))
+        }
+    }
+
+    fn write_doc_comments<W: std::io::Write>(
+        &self,
+        buffer: &mut W,
+        docs: &[Option<&str>],
+        indent: &str,
+    ) -> mlua::Result<()> {
+        for doc in docs.iter().filter_map(|v| *v) {
+            for line in doc.split('\n') {
+                writeln!(buffer, "{indent}-- {line}")?;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn needs_parens_for_optional(ty: &Type) -> bool {
+    matches!(ty, Type::Union(_) | Type::Function { .. })
+}

--- a/src/typed/generator/luau_type_file_tests.rs
+++ b/src/typed/generator/luau_type_file_tests.rs
@@ -1,0 +1,882 @@
+#![cfg(test)]
+#![cfg(feature = "luau")]
+
+use crate::typed::{
+    generator::{Definition, DefinitionBuilder, Definitions, Entry, LuauDefinitionFileGenerator},
+    function::Return,
+    Field, Func, Index, Param, Type, TypedClassBuilder,
+};
+
+/// Write definitions to a string buffer and return the output.
+fn generate(definitions: Definitions) -> String {
+    let gen = LuauDefinitionFileGenerator::new(definitions);
+    let mut out = Vec::new();
+    for (_, writer) in gen.iter() {
+        writer.write(&mut out).unwrap();
+    }
+    String::from_utf8(out).unwrap()
+}
+
+/// Build a single-file Definitions from a DefinitionBuilder.
+fn single(def: DefinitionBuilder) -> Definitions {
+    Definitions::start().define("test", def).finish()
+}
+
+/// Helper: add a typed value entry to a DefinitionBuilder.
+fn with_value(mut builder: DefinitionBuilder, name: &str, ty: Type, doc: Option<&str>) -> DefinitionBuilder {
+    builder.entries.push(Entry::new_with(name, Type::Value(Box::new(ty)), doc));
+    builder
+}
+
+/// Resolve the luau-lsp binary path. If `TEST_LUAU` is set, use its value
+/// as the binary path; otherwise fall back to `"luau-lsp"`. Then check
+/// whether the binary exists on `PATH`. Returns `Some(path)` if found,
+/// `None` if the binary is not available.
+fn find_luau_lsp() -> Option<String> {
+    const LUAU_LSP: &str = "luau-lsp";
+
+    if let Ok(path) = std::env::var("TEST_LUAU") {
+        return (path != "0").then_some(path);
+    }
+
+    // No env var set; probe for luau-lsp on PATH once
+    static PROBED: std::sync::LazyLock<bool> = std::sync::LazyLock::new(|| {
+        std::process::Command::new(LUAU_LSP)
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok()
+    });
+    PROBED.then(|| LUAU_LSP.to_string())
+}
+
+/// If luau-lsp is available, write the output to a temp file and validate it
+/// with `luau-lsp analyze`. Skips validation when the binary is not found.
+fn validate_with_luau_lsp(defs_content: &str, script: &str) {
+    let Some(luau_lsp) = find_luau_lsp() else {
+        return;
+    };
+
+    let dir = tempfile::TempDir::new().expect("failed to create temp dir");
+
+    let defs_path = dir.path().join("defs.d.luau");
+    std::fs::write(&defs_path, defs_content).unwrap();
+
+    let script_path = dir.path().join("test.luau");
+    std::fs::write(&script_path, script).unwrap();
+
+    let output = std::process::Command::new(&luau_lsp)
+        .arg("analyze")
+        .arg(format!("--defs=@test={}", defs_path.display()))
+        .arg(&script_path)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run luau-lsp ({luau_lsp}): {e}"));
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Filter out INFO lines — only keep actual errors
+    let errors: Vec<&str> = stderr
+        .lines()
+        .filter(|l| !l.starts_with("[INFO]"))
+        .collect();
+
+    assert!(
+        errors.is_empty(),
+        "luau-lsp reported errors:\n{}\n\nGenerated definitions:\n{}",
+        errors.join("\n"),
+        defs_content,
+    );
+}
+
+// ========================
+// Output content tests
+// ========================
+
+#[test]
+fn test_enum_type() {
+    let out = generate(single(
+        Definition::start().register_as(
+            "Direction",
+            Type::r#enum([
+                Type::literal("Up"),
+                Type::literal("Down"),
+                Type::literal("Left"),
+                Type::literal("Right"),
+            ]),
+        ),
+    ));
+    assert_eq!(
+        out.trim(),
+        r#"export type Direction = "Up" | "Down" | "Left" | "Right""#
+    );
+}
+
+#[test]
+fn test_alias_type() {
+    let out = generate(single(
+        Definition::start().register_as("StringOrNum", Type::string() | Type::number()),
+    ));
+    assert_eq!(out.trim(), "export type StringOrNum = string | number");
+}
+
+#[test]
+fn test_declare_value() {
+    let out = generate(single(
+        with_value(
+            Definition::start(),
+            "myGlobal",
+            Type::string(),
+            Some("A global"),
+        ),
+    ));
+    assert_eq!(
+        out.trim(),
+        "-- A global
+declare myGlobal: string"
+    );
+}
+
+#[test]
+fn test_declare_function() {
+    let out = generate(single(
+        Definition::start()
+            .param("name", "The name")
+            .function::<String, String>("greet", ()),
+    ));
+    assert_eq!(
+        out.trim(),
+        "declare function greet(name: string): string"
+    );
+}
+
+#[test]
+fn test_function_no_return() {
+    let out = generate(single(
+        Definition::start()
+            .function::<(String,), ()>("log", ()),
+    ));
+    assert_eq!(
+        out.trim(),
+        "declare function log(param0: string): ()"
+    );
+}
+
+#[test]
+fn test_function_multi_return() {
+    let out = generate(single(
+        Definition::start()
+            .function::<String, (bool, String)>("parse", ()),
+    ));
+    assert_eq!(
+        out.trim(),
+        "declare function parse(param0: string): (boolean, string)"
+    );
+}
+
+#[test]
+fn test_class_with_fields() {
+    let out = generate(single(
+        Definition::start().register_as(
+            "Player",
+            Type::class(
+                TypedClassBuilder::default()
+                    .field("name", Type::string(), "Player name")
+                    .field("score", Type::integer(), ()),
+            ),
+        ),
+    ));
+    assert_eq!(
+        out.trim(),
+        "declare class Player
+\t-- Player name
+\tname: string
+\tscore: integer
+end"
+    );
+}
+
+#[test]
+fn test_class_with_methods() {
+    let out = generate(single(
+        Definition::start().register_as(
+            "Counter",
+            Type::class(
+                TypedClassBuilder::default()
+                    .field("value", Type::integer(), ())
+                    .method::<(), i64>("getValue", "Get the current value")
+                    .method::<(i64,), ()>("add", ()),
+            ),
+        ),
+    ));
+    assert_eq!(
+        out.trim(),
+        "declare class Counter
+\tvalue: integer
+\tfunction add(self, param0: integer): ()
+\t-- Get the current value
+\tfunction getValue(self): integer
+end"
+    );
+}
+
+#[test]
+fn test_class_with_functions_separate_table() {
+    let out = generate(single(
+        Definition::start().register_as(
+            "Utils",
+            Type::class(
+                TypedClassBuilder::default()
+                    .function::<String, String>("upper", ()),
+            ),
+        ),
+    ));
+    // Static functions are emitted as a separate global table declaration
+    assert_eq!(
+        out.trim(),
+        "declare class Utils
+end
+
+declare Utils: {
+\tupper: (param0: string) -> string,
+}"
+    );
+}
+
+#[test]
+fn test_class_with_meta_method() {
+    let out = generate(single(
+        Definition::start().register_as(
+            "Obj",
+            Type::class(
+                TypedClassBuilder::default()
+                    .field("x", Type::number(), ())
+                    .meta_method::<(), String>("__tostring", ()),
+            ),
+        ),
+    ));
+    assert_eq!(
+        out.trim(),
+        "declare class Obj
+\tx: number
+\tfunction __tostring(self): string
+end"
+    );
+}
+
+#[test]
+fn test_class_with_meta_field() {
+    let mut builder = TypedClassBuilder::default();
+    builder.meta_fields.insert(
+        Index::from("__count"),
+        Field::new(Type::integer(), "Meta field"),
+    );
+    let out = generate(single(Definition::start().register_as("Tracked", Type::class(builder))));
+    assert_eq!(
+        out.trim(),
+        "declare class Tracked
+\t-- Meta field
+\t__count: integer
+end"
+    );
+}
+
+#[test]
+fn test_optional_type_sugar() {
+    let out = generate(single(
+        Definition::start()
+            .register_as("MaybeStr", Type::string() | Type::nil()),
+    ));
+    assert_eq!(out.trim(), "export type MaybeStr = string?");
+}
+
+#[test]
+fn test_array_type() {
+    let out = generate(single(
+        Definition::start()
+            .register_as("Names", Type::array(Type::string())),
+    ));
+    assert_eq!(out.trim(), "export type Names = { string }");
+}
+
+#[test]
+fn test_map_type() {
+    let out = generate(single(
+        Definition::start().register_as(
+            "Scores",
+            Type::map(Type::string(), Type::integer()),
+        ),
+    ));
+    assert_eq!(out.trim(), "export type Scores = { [string]: integer }");
+}
+
+#[test]
+fn test_table_type() {
+    let out = generate(single(
+        Definition::start().register_as(
+            "Config",
+            Type::table([
+                (Index::from("host"), Type::string()),
+                (Index::from("port"), Type::integer()),
+            ]),
+        ),
+    ));
+    assert_eq!(
+        out.trim(),
+        "export type Config = { host: string, port: integer }"
+    );
+}
+
+#[test]
+fn test_function_type_signature() {
+    let func_type = Type::Function {
+        params: vec![Param {
+            name: Some("x".into()),
+            ty: Type::number(),
+            doc: None,
+        }],
+        returns: vec![Return {
+            ty: Type::boolean(),
+            doc: None,
+        }],
+    };
+    let out = generate(single(
+        Definition::start().register_as("Predicate", func_type),
+    ));
+    assert_eq!(
+        out.trim(),
+        "export type Predicate = (x: number) -> boolean"
+    );
+}
+
+#[test]
+fn test_tuple_homogeneous() {
+    let out = generate(single(
+        Definition::start().register_as(
+            "Pair",
+            Type::tuple([Type::integer(), Type::integer()]),
+        ),
+    ));
+    assert_eq!(out.trim(), "export type Pair = { integer }");
+}
+
+#[test]
+fn test_tuple_heterogeneous() {
+    let out = generate(single(
+        Definition::start().register_as(
+            "Mixed",
+            Type::tuple([Type::string(), Type::integer(), Type::boolean()]),
+        ),
+    ));
+    assert_eq!(
+        out.trim(),
+        "export type Mixed = { string | integer | boolean }"
+    );
+}
+
+#[test]
+fn test_union_type() {
+    let out = generate(single(
+        Definition::start().register_as(
+            "Multi",
+            Type::string() | Type::integer() | Type::boolean(),
+        ),
+    ));
+    assert_eq!(
+        out.trim(),
+        "export type Multi = string | integer | boolean"
+    );
+}
+
+#[test]
+fn test_doc_comments() {
+    let out = generate(single(
+        Definition::start()
+            .document("Greet someone\nThis is multiline")
+            .function::<String, ()>("greet", ()),
+    ));
+    assert_eq!(
+        out.trim(),
+        "-- Greet someone
+-- This is multiline
+declare function greet(param0: string): ()"
+    );
+}
+
+#[test]
+fn test_class_doc_comment() {
+    let mut builder = TypedClassBuilder::default();
+    builder.type_doc = Some("A documented class".into());
+    // register_as uses Entry::new (no doc), so set doc on the entry directly
+    let mut def_builder = Definition::start();
+    def_builder.entries.push(Entry::new_with("Documented", Type::class(builder), Some("Top-level doc")));
+    let out = generate(single(def_builder));
+    assert_eq!(
+        out.trim(),
+        "-- Top-level doc
+-- A documented class
+declare class Documented
+end"
+    );
+}
+
+#[test]
+fn test_enum_referenced_in_value() {
+    let color_enum = Type::r#enum([
+        Type::literal("Red"),
+        Type::literal("Green"),
+        Type::literal("Blue"),
+    ]);
+    let out = generate(single(
+        with_value(
+            Definition::start().register_as("Color", color_enum),
+            "defaultColor",
+            Type::named("Color"),
+            None,
+        ),
+    ));
+    assert_eq!(
+        out.trim(),
+        "export type Color = \"Red\" | \"Green\" | \"Blue\"
+
+declare defaultColor: Color"
+    );
+}
+
+#[test]
+fn test_extension_default() {
+    let definitions = Definitions::start()
+        .define("init", Definition::start().register_as("X", Type::string()))
+        .finish();
+    let gen = LuauDefinitionFileGenerator::new(definitions);
+    let names: Vec<String> = gen.iter().map(|(name, _)| name).collect();
+    assert_eq!(names, vec!["init.d.luau"]);
+}
+
+#[test]
+fn test_extension_custom() {
+    let definitions = Definitions::start()
+        .define("init", Definition::start().register_as("X", Type::string()))
+        .finish();
+    let gen = LuauDefinitionFileGenerator::new(definitions).ext(".luau");
+    let names: Vec<String> = gen.iter().map(|(name, _)| name).collect();
+    assert_eq!(names, vec!["init.luau"]);
+}
+
+// ========================
+// luau-lsp validation tests
+// ========================
+
+#[test]
+fn test_luau_lsp_enum_and_value() {
+    let out = generate(single(
+        with_value(
+            Definition::start().register_as(
+                "Direction",
+                Type::r#enum([
+                    Type::literal("Up"),
+                    Type::literal("Down"),
+                ]),
+            ),
+            "dir",
+            Type::named("Direction"),
+            None,
+        ),
+    ));
+    validate_with_luau_lsp(
+        &out,
+        r#"
+local _d: Direction = dir
+local _u: Direction = "Up"
+"#,
+    );
+}
+
+#[test]
+fn test_luau_lsp_alias() {
+    let out = generate(single(
+        Definition::start()
+            .register_as("StringOrNum", Type::string() | Type::number()),
+    ));
+    validate_with_luau_lsp(
+        &out,
+        r#"
+local _a: StringOrNum = "hello"
+local _b: StringOrNum = 42
+"#,
+    );
+}
+
+#[test]
+fn test_luau_lsp_function() {
+    let out = generate(single(
+        Definition::start()
+            .param("name", "")
+            .function::<String, String>("greet", ()),
+    ));
+    validate_with_luau_lsp(
+        &out,
+        r#"
+local _result: string = greet("world")
+"#,
+    );
+}
+
+#[test]
+fn test_luau_lsp_class_fields_and_methods() {
+    let out = generate(single(
+        with_value(
+            Definition::start().register_as(
+                "Player",
+                Type::class(
+                    TypedClassBuilder::default()
+                        .field("name", Type::string(), ())
+                        .field("score", Type::integer(), ())
+                        .method::<(), String>("getName", ()),
+                ),
+            ),
+            "player",
+            Type::named("Player"),
+            None,
+        ),
+    ));
+    validate_with_luau_lsp(
+        &out,
+        r#"
+local _n: string = player.name
+local _s: integer = player.score
+local _gn: string = player:getName()
+"#,
+    );
+}
+
+#[test]
+fn test_luau_lsp_class_with_meta_method() {
+    let out = generate(single(
+        with_value(
+            Definition::start().register_as(
+                "Obj",
+                Type::class(
+                    TypedClassBuilder::default()
+                        .field("x", Type::number(), ())
+                        .meta_method::<(), String>("__tostring", ()),
+                ),
+            ),
+            "obj",
+            Type::named("Obj"),
+            None,
+        ),
+    ));
+    validate_with_luau_lsp(
+        &out,
+        r#"
+local _s: string = tostring(obj)
+local _x: number = obj.x
+"#,
+    );
+}
+
+#[test]
+fn test_luau_lsp_optional_type() {
+    let out = generate(single(
+        with_value(
+            Definition::start().register_as(
+                "Container",
+                Type::class(
+                    TypedClassBuilder::default()
+                        .field("value", Type::string() | Type::nil(), ()),
+                ),
+            ),
+            "c",
+            Type::named("Container"),
+            None,
+        ),
+    ));
+    assert_eq!(
+        out.trim(),
+        "declare class Container
+\tvalue: string?
+end
+
+declare c: Container"
+    );
+    validate_with_luau_lsp(
+        &out,
+        r#"
+local _v: string? = c.value
+"#,
+    );
+}
+
+#[test]
+fn test_luau_lsp_array_type() {
+    let out = generate(single(
+        with_value(
+            Definition::start().register_as(
+                "Holder",
+                Type::class(
+                    TypedClassBuilder::default()
+                        .field("items", Type::array(Type::string()), ()),
+                ),
+            ),
+            "h",
+            Type::named("Holder"),
+            None,
+        ),
+    ));
+    validate_with_luau_lsp(
+        &out,
+        r#"
+local _items: {string} = h.items
+"#,
+    );
+}
+
+#[test]
+fn test_luau_lsp_map_type() {
+    let out = generate(single(
+        with_value(
+            Definition::start().register_as(
+                "Registry",
+                Type::class(
+                    TypedClassBuilder::default()
+                        .field("data", Type::map(Type::string(), Type::number()), ()),
+                ),
+            ),
+            "reg",
+            Type::named("Registry"),
+            None,
+        ),
+    ));
+    validate_with_luau_lsp(
+        &out,
+        r#"
+local _data: {[string]: number} = reg.data
+"#,
+    );
+}
+
+#[test]
+fn test_luau_lsp_complex_definition() {
+    let out = generate(single(
+        with_value(
+            Definition::start()
+                .register_as(
+                    "System",
+                    Type::r#enum([
+                        Type::literal("Black"),
+                        Type::literal("White"),
+                    ]),
+                )
+                .register_as(
+                    "Color",
+                    Type::r#enum([
+                        Type::named("System"),
+                        Type::integer(),
+                    ]),
+                )
+                .register_as(
+                    "Example",
+                    Type::class(
+                        TypedClassBuilder::default()
+                            .field("color", Type::named("Color"), ())
+                            .method::<(), String>("describe", ())
+                            .meta_method::<(), String>("__tostring", ()),
+                    ),
+                ),
+            "example",
+            Type::named("Example"),
+            None,
+        )
+        .param("name", "")
+        .function::<String, ()>("greet", ()),
+    ));
+    validate_with_luau_lsp(
+        &out,
+        r#"
+local _e: Example = example
+local _c: Color = _e.color
+local _s: string = _e:describe()
+local _ts: string = tostring(_e)
+greet("world")
+"#,
+    );
+}
+
+// ========================
+// Impedance mismatch tests
+// ========================
+// These tests document known precision losses when mapping the
+// mlua-extras Type model to Luau's type system.
+
+/// Variadic<T> erases the inner type to `any` because Luau has no
+/// way to express typed variadics in `declare function` signatures
+/// (only `...: any` is supported in definition files).
+#[test]
+fn test_mismatch_variadic_erases_to_any() {
+    // Variadic<String> should ideally be `...string` but becomes `any`
+    use mlua::Variadic;
+    let ty = <Variadic<String> as crate::typed::Typed>::ty();
+    assert_eq!(
+        ty,
+        Type::any(),
+        "Variadic<String> should erase to any, losing the String type info"
+    );
+
+    // When used as a function parameter, the generated output uses `any`
+    let out = generate(single(
+        Definition::start()
+            .function::<(String, Variadic<i64>), ()>("log", ()),
+    ));
+    assert_eq!(
+        out.trim(),
+        "declare function log(param0: string, param1: any): ()"
+    );
+}
+
+/// Static functions are emitted as a separate global table and can be
+/// called without `self` — no impedance mismatch.
+#[test]
+fn test_luau_lsp_static_functions() {
+    let mut builder = TypedClassBuilder::default()
+        .field("name", Type::string(), ())
+        .method::<(), String>("getName", ());
+    builder.functions.insert(
+        "create".into(),
+        Func {
+            params: vec![Param { name: Some("name".into()), ty: Type::string(), doc: None }],
+            returns: vec![Return { ty: Type::named("Player"), doc: None }],
+            doc: None,
+        },
+    );
+    let out = generate(single(
+        with_value(
+            Definition::start().register_as("Player", Type::class(builder)),
+            "player",
+            Type::named("Player"),
+            None,
+        ),
+    ));
+    validate_with_luau_lsp(
+        &out,
+        "local p: Player = Player.create(\"alice\")\nlocal _n: string = p:getName()\nlocal _name: string = p.name\n",
+    );
+}
+
+/// Static (non-self) functions on a class are emitted as a separate
+/// `declare ClassName: { ... }` table rather than inside the class body,
+/// because `declare class` requires `self` on every function.
+#[test]
+fn test_static_functions_separate_table() {
+    let out = generate(single(
+        Definition::start().register_as(
+            "Factory",
+            Type::class(
+                TypedClassBuilder::default()
+                    .function::<String, i64>("create", "A static factory method"),
+            ),
+        ),
+    ));
+    assert_eq!(
+        out.trim(),
+        "declare class Factory
+end
+
+declare Factory: {
+\t-- A static factory method
+\tcreate: (param0: string) -> integer,
+}"
+    );
+}
+
+/// Heterogeneous tuples lose positional type information because Luau
+/// has no tuple type syntax. A tuple like (string, integer, boolean)
+/// becomes `{ string | integer | boolean }` — an array of the union
+/// of all element types, losing the guarantee of which type is at
+/// which position.
+#[test]
+fn test_mismatch_heterogeneous_tuple_loses_position() {
+    let out = generate(single(
+        Definition::start().register_as(
+            "Record",
+            Type::tuple([Type::string(), Type::integer(), Type::boolean()]),
+        ),
+    ));
+    // Instead of something like [string, integer, boolean], we get
+    // an array whose element type is the union of all tuple types
+    assert_eq!(
+        out.trim(),
+        "export type Record = { string | integer | boolean }",
+        "Heterogeneous tuple should flatten to union array"
+    );
+}
+
+/// Luau treats `integer` and `number` as distinct, incompatible types
+/// in definition files. `local x: number = some_integer` is a type
+/// error. The mlua-extras model maps Rust integer types (i32, u64, etc)
+/// to `integer` and float types (f32, f64) to `number`, which is
+/// faithful but means consumers must be precise about which they use.
+#[test]
+fn test_mismatch_integer_vs_number() {
+    let out = generate(single(
+        with_value(
+            Definition::start().register_as(
+                "Stats",
+                Type::class(
+                    TypedClassBuilder::default()
+                        .field("count", Type::integer(), "An integer field")
+                        .field("ratio", Type::number(), "A float field"),
+                ),
+            ),
+            "stats",
+            Type::named("Stats"),
+            None,
+        ),
+    ));
+    assert_eq!(
+        out.trim(),
+        "declare class Stats
+\t-- An integer field
+\tcount: integer
+\t-- A float field
+\tratio: number
+end
+
+declare stats: Stats"
+    );
+
+    // Each field must be consumed with its exact declared type
+    validate_with_luau_lsp(
+        &out,
+        r#"
+local _c: integer = stats.count
+local _r: number = stats.ratio
+"#,
+    );
+}
+
+/// Enum variants that carry tuple data lose their structure. In the
+/// mlua-extras model, an enum variant can be `Type::tuple([Type::integer()])`
+/// which flattens to `{ integer }` — an array type. Nested enum
+/// variants with different tuple arities all become `{ T }` arrays,
+/// losing the distinction between e.g. a 2-element and 3-element variant.
+#[test]
+fn test_mismatch_enum_tuple_variants_flatten() {
+    // An enum where one variant carries a tuple of (integer, string)
+    // and another carries just a string
+    let out = generate(single(
+        Definition::start().register_as(
+            "Payload",
+            Type::r#enum([
+                Type::literal("None"),
+                Type::tuple([Type::integer(), Type::string()]),
+                Type::tuple([Type::boolean()]),
+            ]),
+        ),
+    ));
+    // The tuple variants become union-arrays, losing arity info
+    assert_eq!(
+        out.trim(),
+        "export type Payload = \"None\" | { integer | string } | { boolean }"
+    );
+}

--- a/src/typed/generator/mod.rs
+++ b/src/typed/generator/mod.rs
@@ -13,6 +13,11 @@ use super::{
 mod type_file;
 pub use type_file::DefinitionFileGenerator;
 
+mod luau_type_file;
+pub use luau_type_file::LuauDefinitionFileGenerator;
+
+mod luau_type_file_tests;
+
 /// Representation of a type that is defined in the definition file.
 ///
 /// This type has a name and additional documentation that can be displayed


### PR DESCRIPTION
[Note: this is based on the changes in #19; those should be reviewed and landed first. When reviewing this PR, just look at the most recent commit as the others are from that other PR]

This generates a luau compatible definition file from the Definitions.

A LUAU.md doc file is included that describes the format and any nuances
that are part of mapping from mlua-extra's Type model to that format.

In particular, there are undocumented features of the grammar that are
not discussed in the luau docs at https://luau.org/types/ or
https://luau.org/grammar/ that can be reverse engineered from examples
in the luau-lsp repo (like
https://github.com/JohnnyMorganz/luau-lsp/blob/main/scripts/globalTypes.d.luau)
so it's worth summarizing that information here so that it is not lost
the moment I context switch away.

Tests are included to exercise the generator and verify that the
results are acceptable to the luau-lsp.  There's very good coverage
here, so this should help to both demonstrate the syntax and act
as regression tests.