### PR TITLE
Update luau definitions

### DIFF
--- a/examples/typed.rs
+++ b/examples/typed.rs
@@ -173,6 +173,7 @@ fn main() -> mlua::Result<()> {
                 .register::<Color>("Color")
                 .register::<Example>("Example")
                 .value::<Example>("example")
+                .document("Greet someone")
                 .param("name", "Name of the person to greet")
                 .function::<String, ()>("greet", ())
                 .param("color", "Color to print to stdout")

--- a/examples/types/init.d.lua
+++ b/examples/types/init.d.lua
@@ -1,7 +1,5 @@
 --- @meta
 
---- @alias System SystemColorBlack | SystemColorRed | SystemColorGreen | SystemColorYellow | SystemColorBlue | SystemColorCyan | SystemColorMagenta | SystemColorWhite
-
 --- @alias SystemColorEnum "Black"
 ---  | "Red"
 ---  | "Green"
@@ -29,7 +27,7 @@
 
 --- @class SystemColorWhite: _SystemColor
 
---- @alias Color ColorSystem | ColorXterm | ColorRgb
+--- @alias System SystemColorBlack | SystemColorRed | SystemColorGreen | SystemColorYellow | SystemColorBlue | SystemColorCyan | SystemColorMagenta | SystemColorWhite
 
 --- @alias ColorEnum "System"
 ---  | "Xterm"
@@ -50,6 +48,8 @@ local _CLASS__Color_ = {
 --- @class ColorXterm: _Color
 
 --- @class ColorRgb: _Color
+
+--- @alias Color ColorSystem | ColorXterm | ColorRgb
 
 --- This is a doc comment section for the overall type
 --- @class Example
@@ -73,6 +73,7 @@ local _CLASS_Example_ = {
 --- @type Example
 example = nil
 
+--- Greet someone
 --- @param name string Name of the person to greet
 function greet(name) end
 

--- a/examples/types/init.d.luau
+++ b/examples/types/init.d.luau
@@ -1,68 +1,92 @@
-export type System = SystemColorBlack | SystemColorRed | SystemColorGreen | SystemColorYellow | SystemColorBlue | SystemColorCyan | SystemColorMagenta | SystemColorWhite
-
 export type SystemColorEnum = "Black" | "Red" | "Green" | "Yellow" | "Blue" | "Cyan" | "Magenta" | "White"
 
 declare class _SystemColor
 end
 
-declare class SystemColorBlack
+
+declare class SystemColorBlack extends _SystemColor
 end
 
-declare class SystemColorRed
+
+declare class SystemColorRed extends _SystemColor
 end
 
-declare class SystemColorGreen
+
+declare class SystemColorGreen extends _SystemColor
 end
 
-declare class SystemColorYellow
+
+declare class SystemColorYellow extends _SystemColor
 end
 
-declare class SystemColorBlue
+
+declare class SystemColorBlue extends _SystemColor
 end
 
-declare class SystemColorCyan
+
+declare class SystemColorCyan extends _SystemColor
 end
 
-declare class SystemColorMagenta
+
+declare class SystemColorMagenta extends _SystemColor
 end
 
-declare class SystemColorWhite
+
+declare class SystemColorWhite extends _SystemColor
 end
 
-export type Color = ColorSystem | ColorXterm | ColorRgb
+
+export type System = SystemColorBlack | SystemColorRed | SystemColorGreen | SystemColorYellow | SystemColorBlue | SystemColorCyan | SystemColorMagenta | SystemColorWhite
 
 export type ColorEnum = "System" | "Xterm" | "Rgb"
 
--- Representation of a color
+--- Representation of a color
 declare class _Color
+	--- @return string
 	function __tostring(self): string
 end
 
-declare class ColorSystem
+
+declare class ColorSystem extends _Color
 end
 
-declare class ColorXterm
+
+declare class ColorXterm extends _Color
 end
 
-declare class ColorRgb
+
+declare class ColorRgb extends _Color
 end
 
--- This is a doc comment section for the overall type
+
+export type Color = ColorSystem | ColorXterm | ColorRgb
+
+--- This is a doc comment section for the overall type
 declare class Example
-	-- Example complex type
+	--- Example complex type
 	color: Color
+	--- @return string
 	function __tostring(self): string
 end
+
+--- Log a specific format with any lua types
+--- @param format string -- String to pass to the formatter.
+--- @param ... any -- Arguments to pass to the formatter.
+declare function Example_LogAny(format: string, ...: any): ()
+--- print all items
+--- @param ... any
+declare function Example_printAll(...: any): ()
 
 declare Example: {
-	-- Log a specific format with any lua types
-	LogAny: (format: string, ...: any) -> (),
-	-- print all items
-	printAll: (...: any) -> (),
+	LogAny: typeof(Example_LogAny),
+	printAll: typeof(Example_printAll),
 }
 
 declare example: Example
 
+--- Greet someone
+--- @param name string -- Name of the person to greet
 declare function greet(name: string): ()
 
+--- @param color Color -- Color to print to stdout
 declare function printColor(color: Color): ()

--- a/examples/types/test.luau
+++ b/examples/types/test.luau
@@ -1,0 +1,1 @@
+local _color: Color = ({} :: any);

--- a/mlua_extras_derive/src/lib.rs
+++ b/mlua_extras_derive/src/lib.rs
@@ -51,19 +51,12 @@ pub fn derive_typed(input: TokenStream) -> TokenStream {
                         mlua_extras::typed::Type::class(mlua_extras::typed::TypedClassBuilder::new::<#name>())
                     }
 
-                    fn as_param() -> mlua_extras::typed::Param {
-                        mlua_extras::typed::Param {
-                            doc: None,
-                            name: None,
-                            ty: mlua_extras::typed::Type::named(#label),
-                        }
+                    fn as_param() -> mlua_extras::typed::Type {
+                        mlua_extras::typed::Type::named(#label)
                     }
 
-                    fn as_return() -> mlua_extras::typed::Return {
-                        mlua_extras::typed::Return {
-                            doc: None,
-                            ty: mlua_extras::typed::Type::named(#label),
-                        }
+                    fn as_return() -> mlua_extras::typed::Type {
+                        mlua_extras::typed::Type::named(#label)
                     }
                 }
             )
@@ -115,19 +108,12 @@ pub fn derive_typed(input: TokenStream) -> TokenStream {
                         ]
                     }
 
-                    fn as_param() -> mlua_extras::typed::Param {
-                        mlua_extras::typed::Param {
-                            doc: None,
-                            name: None,
-                            ty: mlua_extras::typed::Type::named(#label),
-                        }
+                    fn as_param() -> mlua_extras::typed::Type {
+                        mlua_extras::typed::Type::named(#label)
                     }
 
-                    fn as_return() -> mlua_extras::typed::Return {
-                        mlua_extras::typed::Return {
-                            doc: None,
-                            ty: mlua_extras::typed::Type::named(#label),
-                        }
+                    fn as_return() -> mlua_extras::typed::Type {
+                        mlua_extras::typed::Type::named(#label)
                     }
                 }
             )

--- a/src/typed/class/standard.rs
+++ b/src/typed/class/standard.rs
@@ -293,7 +293,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
         V: IntoLua + Clone + 'static + Typed,
     {
         let name: Cow<'static, str> = name.into().into();
-        let ty = self.queued_ty.take().unwrap_or(V::as_param().ty);
+        let ty = self.queued_ty.take().unwrap_or(V::as_param());
         self.static_fields
             .entry(name.into())
             .and_modify({
@@ -316,7 +316,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
         F: 'static + MaybeSend + FnMut(&Lua, AnyUserData, A) -> mlua::Result<()>,
     {
         let name: Cow<'static, str> = name.into().into();
-        let ty = self.queued_ty.take().unwrap_or(A::as_param().ty);
+        let ty = self.queued_ty.take().unwrap_or(A::as_param());
         self.static_fields
             .entry(name.into())
             .and_modify({
@@ -339,7 +339,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
         F: 'static + MaybeSend + Fn(&Lua, AnyUserData) -> mlua::Result<R>,
     {
         let name: Cow<'static, str> = name.into().into();
-        let ty = self.queued_ty.take().unwrap_or(R::as_return().ty);
+        let ty = self.queued_ty.take().unwrap_or(R::as_return());
         self.static_fields
             .entry(name.into())
             .and_modify({
@@ -364,7 +364,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
         SET: 'static + MaybeSend + Fn(&Lua, AnyUserData, A) -> mlua::Result<()>,
     {
         let name: Cow<'static, str> = name.into().into();
-        let ty = self.queued_ty.take().unwrap_or(A::as_param().ty | R::as_return().ty);
+        let ty = self.queued_ty.take().unwrap_or(A::as_param() | R::as_return());
         self.static_fields
             .entry(name.into())
             .and_modify({
@@ -387,7 +387,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
         M: 'static + MaybeSend + FnMut(&Lua, &mut T, A) -> mlua::Result<()>,
     {
         let name: Cow<'static, str> = name.into().into();
-        let ty = self.queued_ty.take().unwrap_or(A::as_param().ty);
+        let ty = self.queued_ty.take().unwrap_or(A::as_param());
         self.fields
             .entry(name.into())
             .and_modify({
@@ -410,7 +410,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
         M: 'static + MaybeSend + Fn(&Lua, &T) -> mlua::Result<R>,
     {
         let name: Cow<'static, str> = name.into().into();
-        let ty = self.queued_ty.take().unwrap_or(R::as_return().ty);
+        let ty = self.queued_ty.take().unwrap_or(R::as_return());
         self.fields
             .entry(name.into())
             .and_modify({
@@ -435,7 +435,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
         SET: 'static + MaybeSend + Fn(&Lua, &mut T, A) -> mlua::Result<()>,
     {
         let name: Cow<'static, str> = name.into().into();
-        let ty = self.queued_ty.take().unwrap_or(A::as_param().ty | R::as_return().ty);
+        let ty = self.queued_ty.take().unwrap_or(A::as_param() | R::as_return());
         self.fields
             .entry(name.into())
             .and_modify({
@@ -456,7 +456,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
         V: IntoLua + Typed + 'static,
     {
         let name: Cow<'static, str> = meta.into().into();
-        let ty = self.queued_ty.take().unwrap_or(V::as_param().ty);
+        let ty = self.queued_ty.take().unwrap_or(V::as_param());
         self.meta_fields
             .entry(name.into())
             .and_modify({
@@ -478,7 +478,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
             R: IntoLua + Typed {
 
         let name: Cow<'static, str> = meta.into().into();
-        let ty = self.queued_ty.take().unwrap_or(R::as_return().ty);
+        let ty = self.queued_ty.take().unwrap_or(R::as_return());
         self.meta_fields
             .entry(name.into())
             .and_modify({
@@ -525,7 +525,7 @@ impl<T: TypedUserData> TypedDataMethods<T> for TypedClassBuilder {
     }
 
     fn index<I: Typed>(&mut self, idx: usize, doc: impl IntoDocComment) -> &mut Self {
-        self.fields.insert(idx.into(), Field { ty: I::as_param().ty, doc: doc.into_doc_comment() });
+        self.fields.insert(idx.into(), Field { ty: I::as_param(), doc: doc.into_doc_comment() });
         self
     }
 

--- a/src/typed/generator/luau_type_file.rs
+++ b/src/typed/generator/luau_type_file.rs
@@ -122,7 +122,11 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                         &[definition.doc.as_deref(), type_data.type_doc.as_deref()],
                         "",
                     )?;
-                    writeln!(buffer, "declare class {}", definition.name)?;
+                    write!(buffer, "declare class {}", definition.name)?;
+                    if !type_data.derives.is_empty() {
+                        write!(buffer, " extends {}", type_data.derives.join(", "))?;
+                    }
+                    writeln!(buffer)?;
 
                     // Static fields
                     for (name, field) in type_data.static_fields.iter() {
@@ -178,6 +182,16 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                             &[func.doc.as_deref()],
                             "\t",
                         )?;
+                        self.write_param_doc_comments(
+                            &mut buffer,
+                            &func.params,
+                            "\t"
+                        )?;
+                        self.write_return_doc_comments(
+                            &mut buffer,
+                            &func.returns,
+                            "\t"
+                        )?;
                         writeln!(
                             buffer,
                             "\tfunction {}(self{}{}): {}",
@@ -193,24 +207,50 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                     // Static functions and meta_functions are emitted as a
                     // separate global table declaration, since `declare class`
                     // requires `self` on every function.
+                    //
+                    // They are first declared themselves to give them richer type information.
+                    // Then they are added to a global table declaration with `typeof()`.
                     let static_fns: Vec<_> = type_data.functions.iter()
                         .chain(type_data.meta_functions.iter())
                         .collect();
+
+                    if !static_fns.is_empty() {
+                        writeln!(buffer)?;
+                    }
+
+                    for (name, func) in static_fns.iter() {
+                        self.write_doc_comments(
+                            &mut buffer,
+                            &[func.doc.as_deref()],
+                            "",
+                        )?;
+                        self.write_param_doc_comments(
+                            &mut buffer,
+                            &func.params,
+                            ""
+                        )?;
+                        self.write_return_doc_comments(
+                            &mut buffer,
+                            &func.returns,
+                            ""
+                        )?;
+                        writeln!(
+                            buffer,
+                            "declare function {}_{name}({}): {}",
+                            definition.name,
+                            self.param_list(&func.params)?,
+                            self.return_type(&func.returns)?,
+                        )?;
+                    }
+
                     if !static_fns.is_empty() {
                         writeln!(buffer)?;
                         writeln!(buffer, "declare {}: {{", definition.name)?;
-                        for (name, func) in &static_fns {
-                            self.write_doc_comments(
-                                &mut buffer,
-                                &[func.doc.as_deref()],
-                                "\t",
-                            )?;
+                        for (name, _func) in &static_fns {
                             writeln!(
                                 buffer,
-                                "\t{}: ({}) -> {},",
-                                name,
-                                self.param_list(&func.params)?,
-                                self.return_type(&func.returns)?,
+                                "\t{name}: typeof({}_{name}),",
+                                definition.name,
                             )?;
                         }
                         writeln!(buffer, "}}")?;
@@ -255,6 +295,16 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                         &mut buffer,
                         &[definition.doc.as_deref()],
                         "",
+                    )?;
+                    self.write_param_doc_comments(
+                        &mut buffer,
+                        &params,
+                        ""
+                    )?;
+                    self.write_return_doc_comments(
+                        &mut buffer,
+                        &returns,
+                        ""
                     )?;
                     writeln!(
                         buffer,
@@ -387,7 +437,7 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                     .name
                     .as_deref()
                     .map(|n| n.to_string())
-                    .unwrap_or_else(|| format!("param{i}"));
+                    .unwrap_or_else(|| format!("param{}", i + 1));
                 Ok(format!("{}: {}", name, self.type_signature(&p.ty)?))
             })
             .collect::<mlua::Result<Vec<_>>>()
@@ -417,8 +467,45 @@ impl<'writer> LuauDefinitionWriter<'writer> {
     ) -> mlua::Result<()> {
         for doc in docs.iter().filter_map(|v| *v) {
             for line in doc.split('\n') {
-                writeln!(buffer, "{indent}-- {line}")?;
+                writeln!(buffer, "{indent}--- {line}")?;
             }
+        }
+        Ok(())
+    }
+
+    fn write_param_doc_comments<W: std::io::Write>(
+        &self,
+        buffer: &mut W,
+        params: &[Param],
+        indent: &str,
+    ) -> mlua::Result<()> {
+        for (i, p) in params.iter().enumerate().filter(|(_, p)| p.doc.is_some()) {
+            write!(buffer, "{indent}--- @param {} {}",
+                p.name.as_deref().map(|v| v.to_string()).unwrap_or_else(|| format!("param{}", i + 1)),
+                self.type_signature(&p.ty)?
+            )?;
+            if let Some(doc) = p.doc.as_deref() {
+                let doc = doc.replace('\n', "");
+                write!(buffer, " -- {doc}")?;
+            }
+            writeln!(buffer)?;
+        }
+        Ok(())
+    }
+
+    fn write_return_doc_comments<W: std::io::Write>(
+        &self,
+        buffer: &mut W,
+        returns: &[Return],
+        indent: &str,
+    ) -> mlua::Result<()> {
+        for (i, r) in returns.iter().enumerate().filter(|(_, r)| r.doc.is_some()) {
+            write!(buffer, "{indent}--- @return {}", self.type_signature(&r.ty)?)?;
+            if let Some(doc) = r.doc.as_deref() {
+                let doc = doc.replace('\n', "");
+                write!(buffer, " -- #{} {doc}", i + 1)?;
+            }
+            writeln!(buffer)?;
         }
         Ok(())
     }

--- a/src/typed/generator/luau_type_file_tests.rs
+++ b/src/typed/generator/luau_type_file_tests.rs
@@ -132,7 +132,7 @@ fn test_declare_value() {
     ));
     assert_eq!(
         out.trim(),
-        "-- A global
+        "--- A global
 declare myGlobal: string"
     );
 }
@@ -142,11 +142,14 @@ fn test_declare_function() {
     let out = generate(single(
         Definition::start()
             .param("name", "The name")
+            .ret("Formatted greeting")
             .function::<String, String>("greet", ()),
     ));
     assert_eq!(
         out.trim(),
-        "declare function greet(name: string): string"
+        "--- @param name string -- The name
+--- @return string -- #1 Formatted greeting
+declare function greet(name: string): string"
     );
 }
 
@@ -158,7 +161,7 @@ fn test_function_no_return() {
     ));
     assert_eq!(
         out.trim(),
-        "declare function log(param0: string): ()"
+        "declare function log(param1: string): ()"
     );
 }
 
@@ -170,7 +173,7 @@ fn test_function_multi_return() {
     ));
     assert_eq!(
         out.trim(),
-        "declare function parse(param0: string): (boolean, string)"
+        "declare function parse(param1: string): (boolean, string)"
     );
 }
 
@@ -189,7 +192,7 @@ fn test_class_with_fields() {
     assert_eq!(
         out.trim(),
         "declare class Player
-\t-- Player name
+\t--- Player name
 \tname: string
 \tscore: number
 end"
@@ -213,8 +216,8 @@ fn test_class_with_methods() {
         out.trim(),
         "declare class Counter
 \tvalue: number
-\tfunction add(self, param0: number): ()
-\t-- Get the current value
+\tfunction add(self, param1: number): ()
+\t--- Get the current value
 \tfunction getValue(self): number
 end"
     );
@@ -237,8 +240,10 @@ fn test_class_with_functions_separate_table() {
         "declare class Utils
 end
 
+declare function Utils_upper(param1: string): string
+
 declare Utils: {
-\tupper: (param0: string) -> string,
+\tupper: typeof(Utils_upper),
 }"
     );
 }
@@ -275,7 +280,7 @@ fn test_class_with_meta_field() {
     assert_eq!(
         out.trim(),
         "declare class Tracked
-\t-- Meta field
+\t--- Meta field
 \t__count: number
 end"
     );
@@ -397,9 +402,9 @@ fn test_doc_comments() {
     ));
     assert_eq!(
         out.trim(),
-        "-- Greet someone
--- This is multiline
-declare function greet(param0: string): ()"
+        "--- Greet someone
+--- This is multiline
+declare function greet(param1: string): ()"
     );
 }
 
@@ -413,8 +418,8 @@ fn test_class_doc_comment() {
     let out = generate(single(def_builder));
     assert_eq!(
         out.trim(),
-        "-- Top-level doc
--- A documented class
+        "--- Top-level doc
+--- A documented class
 declare class Documented
 end"
     );
@@ -730,7 +735,7 @@ fn test_mismatch_variadic_erases_to_any() {
     ));
     assert_eq!(
         out.trim(),
-        "declare function log(param0: string, param1: any): ()"
+        "declare function log(param1: string, param2: any): ()"
     );
 }
 
@@ -782,9 +787,11 @@ fn test_static_functions_separate_table() {
         "declare class Factory
 end
 
+--- A static factory method
+declare function Factory_create(param1: string): number
+
 declare Factory: {
-\t-- A static factory method
-\tcreate: (param0: string) -> number,
+\tcreate: typeof(Factory_create),
 }"
     );
 }
@@ -835,9 +842,9 @@ fn test_integer_maps_to_number() {
     assert_eq!(
         out.trim(),
         "declare class Stats
-\t-- An integer field
+\t--- An integer field
 \tcount: number
-\t-- A float field
+\t--- A float field
 \tratio: number
 end
 

--- a/src/typed/generator/mod.rs
+++ b/src/typed/generator/mod.rs
@@ -156,14 +156,6 @@ impl DefinitionBuilder {
 
     /// Register a type
     pub fn register<T: Typed>(mut self, name: impl Into<Cow<'static, str>>) -> Self {
-        let ty = T::ty();
-        let ty = match &ty {
-            Type::Class(_) | Type::Enum(_) => ty,
-            _ => Type::alias(ty),
-        };
-
-        self.entries.push(Entry::new(name.into(), ty.into()));
-
         for (name, ty) in T::implicit().into_iter() {
             let ty = match ty {
                 Type::Class(_) | Type::Enum(_) => ty,
@@ -172,6 +164,13 @@ impl DefinitionBuilder {
             self.entries.push(Entry::new(name, ty));
         }
 
+        let ty = T::ty();
+        let ty = match &ty {
+            Type::Class(_) | Type::Enum(_) => ty,
+            _ => Type::alias(ty),
+        };
+
+        self.entries.push(Entry::new(name.into(), ty.into()));
         self
     }
 

--- a/src/typed/mod.rs
+++ b/src/typed/mod.rs
@@ -32,20 +32,13 @@ pub trait Typed {
     }
 
     /// Get the type as a function parameter
-    fn as_param() -> Param {
-        Param {
-            doc: None,
-            name: None,
-            ty: Self::ty(),
-        }
+    fn as_param() -> Type {
+        Self::ty()
     }
 
     /// Get the type as a function return
-    fn as_return() -> Return {
-        Return {
-            doc: None,
-            ty: Self::ty(),
-        }
+    fn as_return() -> Type {
+        Self::ty()
     }
 }
 
@@ -676,7 +669,11 @@ macro_rules! impl_typed_multi_value {
             #[allow(non_snake_case)]
             fn get_types_as_params() -> Vec<Param> {
                 Vec::from([
-                    $($name::as_param(),)*
+                    $(Param {
+                        doc: None,
+                        name: None,
+                        ty: $name::as_param(),
+                    },)*
                 ])
             }
 
@@ -684,7 +681,10 @@ macro_rules! impl_typed_multi_value {
             #[allow(non_snake_case)]
             fn get_types_as_returns() -> Vec<Return> {
                 Vec::from([
-                    $($name::as_return(),)*
+                    $(Return {
+                        doc: None,
+                        ty: $name::as_return(),
+                    },)*
                 ])
             }
         }
@@ -696,11 +696,11 @@ where
     A: Typed,
 {
     fn get_types_as_params() -> Vec<Param> {
-        Vec::from([A::as_param()])
+        Vec::from([Param { name: None, doc: None, ty: A::as_param()}])
     }
 
     fn get_types_as_returns() -> Vec<Return> {
-        Vec::from([A::as_return()])
+        Vec::from([Return { doc: None, ty: A::as_return() }])
     }
 }
 


### PR DESCRIPTION
- Add rich static function declaration by defining them as `declare function` then using `typeof` in the global table declaration.
- Add `@param` doc comments to function declarations
- Add `@return` doc  comments to function declarations
- Make `param{i}` start at 1 instead of 0