### PR TITLE
fix wrapper types calling incorrect Typed functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,16 +25,18 @@ jobs:
           - lua54,vendored
           - lua54,vendored,send
           - lua54,vendored,async
-          - lua54,vendored,derive
+          - lua54,vendored,macros
+          - lua54,vendored,macros,userdata-wrappers
           - lua54,vendored,send,async
-          - lua54,vendored,send,derive
-          - lua54,vendored,async,derive
-          - lua54,vendored,send,async,derive
-          # Full feature set including serialize and macros
-          - lua54,vendored,send,async,derive,serialize,macros
+          - lua54,vendored,send,macros
+          - lua54,vendored,async,macros
+          - lua54,vendored,send,async,macros
+          # Full feature set including serde and macros
+          - lua54,vendored,send,async,serde,macros
           # Luau feature combinations
           - luau,vendored
-          - luau,vendored,send,async,derive,serialize,macros
+          - luau,vendored,macros,userdata-wrappers
+          - luau,vendored,send,async,serde,macros
     steps:
       - uses: actions/checkout@v6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,23 +11,23 @@ repository = "https://github.com/Tired-Fox/mlua-extras"
 keywords = ["lua", "mlua", "luajit", "luau", "scripting"]
 
 [package.metadata.docs.rs]
-features = ["mlua", "lua54", "send", "async", "derive", "vendored"]
+features = ["mlua", "lua54", "send", "async", "macros", "vendored"]
 
 [features]
 mlua = ["dep:mlua"]
-lua54 = ["mlua/lua54", "mlua"]
-lua53 = ["mlua/lua53", "mlua"]
-lua52 = ["mlua/lua52", "mlua"]
-lua51 = ["mlua/lua51", "mlua"]
-luajit = ["mlua/luajit", "mlua"]
-luau = ["mlua/luau", "mlua"]
-vendored = ["mlua/vendored", "mlua"]
-serialize = ["mlua/serialize", "mlua"]
-macros = ["mlua/macros", "mlua"]
-module = ["mlua/module", "mlua"]
-send = ["mlua/send", "mlua"]
-async = ["mlua/async", "mlua"]
-derive = ["dep:mlua-extras-derive"]
+lua54 = ["mlua", "mlua/lua54"]
+lua53 = ["mlua", "mlua/lua53"]
+lua52 = ["mlua", "mlua/lua52"]
+lua51 = ["mlua", "mlua/lua51"]
+luajit = ["mlua", "mlua/luajit"]
+luau = ["mlua", "mlua/luau"]
+vendored = ["mlua/vendored"]
+serde = ["mlua/serde"]
+macros = ["mlua/macros", "dep:mlua-extras-derive"]
+module = ["mlua/module"]
+send = ["mlua/send"]
+async = ["mlua/async"]
+userdata-wrappers = ["mlua/userdata-wrappers"]
 
 [dev-dependencies]
 serde = { version = "1.0.228", features = ["derive"] }
@@ -42,7 +42,7 @@ strum = { version = "0.27.2", features = ["derive"], default-features = false }
 
 [[example]]
 name = "macros"
-required-features = ["mlua", "derive"]
+required-features = ["mlua", "macros"]
 
 [[example]]
 name = "enum_and_tuple"
@@ -54,4 +54,4 @@ required-features = ["mlua"]
 
 [[example]]
 name = "typed"
-required-features = ["mlua", "derive", "serialize"]
+required-features = ["mlua", "macros", "serde"]

--- a/mlua_extras_derive/Cargo.toml
+++ b/mlua_extras_derive/Cargo.toml
@@ -11,7 +11,7 @@ description = "MLua extras macros"
 readme = "README.md"
 homepage = "https://github.com/Tired-Fox/mlua-extras"
 repository = "https://github.com/Tired-Fox/mlua-extras/tree/main/mlua_extras_derive"
-keywords = ["lua", "types", "mlua", "macros", "derive"]
+keywords = ["lua", "types", "mlua", "macros"]
 
 [dependencies]
 darling = "0.23.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@ pub mod extras;
 #[cfg(feature="mlua")]
 pub use mlua;
 
-#[cfg(feature="derive")]
+#[cfg(feature="macros")]
 pub use mlua_extras_derive::{Typed, UserData, user_data_impl};
 
 #[cfg(feature = "send")]
@@ -21,10 +21,10 @@ pub trait MaybeSend {}
 #[cfg(not(feature = "send"))]
 impl<T> MaybeSend for T {}
 
-#[cfg(feature = "derive")]
+#[cfg(feature = "macros")]
 #[doc(hidden)]
 pub trait __DefaultAutoMethods: Sized {
     fn __auto_add_methods<M>(_m: &mut M) {}
 }
-#[cfg(feature = "derive")]
+#[cfg(feature = "macros")]
 impl<T: Sized> __DefaultAutoMethods for T {}

--- a/src/typed/class/wrapped.rs
+++ b/src/typed/class/wrapped.rs
@@ -265,7 +265,7 @@ impl<'ctx, T: UserData, U: UserDataMethods<T>> TypedDataMethods<T> for WrappedBu
 }
 
 #[cfg(test)]
-#[cfg(all(feature = "async", feature = "derive"))]
+#[cfg(all(feature = "async", feature = "macros"))]
 mod tests {
     use super::*;
     use crate as mlua_extras;

--- a/src/typed/mod.rs
+++ b/src/typed/mod.rs
@@ -9,243 +9,14 @@ pub use class::{
 };
 
 use std::{
-    borrow::Cow,
-    cell::{Cell, RefCell},
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
-    marker::PhantomData,
-    rc::Rc,
-    sync::{Arc, Mutex},
+    borrow::Cow, collections::{BTreeMap, BTreeSet, HashMap, HashSet}, marker::PhantomData
 };
+#[cfg(feature="userdata-wrappers")]
+use std::{sync::{Arc, Mutex}, cell::{Cell, RefCell}, rc::Rc};
 
 pub use function::{Param, Return, TypedFunction};
 
 use mlua::{IntoLua, MetaMethod, Value, Variadic};
-
-/// Add a lua [`Type`] representation to a rust type
-pub trait Typed {
-    /// Get the type representation
-    fn ty() -> Type;
-
-    #[inline(always)]
-    fn implicit() -> impl IntoIterator<Item = (&'static str, Type)> {
-        []
-    }
-
-    /// Get the type as a function parameter
-    fn as_param() -> Type {
-        Self::ty()
-    }
-
-    /// Get the type as a function return
-    fn as_return() -> Type {
-        Self::ty()
-    }
-}
-
-#[macro_export]
-macro_rules! join_types {
-    ($($ty:expr),+) => {
-        $crate::typed::Type::union([
-            $($crate::typed::Type::from($ty),)+
-        ])
-    };
-}
-
-macro_rules! impl_static_typed {
-    {
-        $(
-            $($target: ty)|*
-            => $name: literal),*
-            $(,)?
-    } => {
-        $(
-            $(
-                impl Typed for $target {
-                    fn ty() -> Type {
-                        Type::named($name)
-                    }
-                }
-            )*
-        )*
-    };
-}
-
-macro_rules! impl_static_typed_generic {
-    {
-        $(
-            $(for<$($lt: lifetime),+> $target: ty)|*
-            => $name: literal),*
-            $(,)?
-    } => {
-        $(
-            $(
-                impl<$($lt,)+> Typed for $target {
-                    fn ty() -> Type {
-                        Type::named($name)
-                    }
-                }
-            )*
-        )*
-    };
-}
-
-impl_static_typed! {
-    mlua::LightUserData => "lightuserdata",
-    mlua::Error => "error",
-    String | &str => "string",
-    u8 | u16 | u32 | u64 | usize | u128 | i8 | i16 | i32 | i64 | isize | i128 => "integer",
-    f32 | f64 => "number",
-    bool => "boolean",
-
-    mlua::Function => "fun()",
-    mlua::Table => "table",
-    mlua::AnyUserData => "userdata",
-    mlua::String => "string",
-    mlua::Thread => "thread",
-}
-
-impl_static_typed_generic! {
-    for<'a> Cow<'a, str> => "string",
-}
-
-impl Typed for mlua::Value {
-    fn ty() -> Type {
-        Type::Single("any".into())
-    }
-}
-
-impl<T: Typed> Typed for Variadic<T> {
-    /// ...type
-    fn ty() -> Type {
-        Type::any()
-    }
-}
-
-/// {type} | nil
-impl<T: Typed> Typed for Option<T> {
-    fn ty() -> Type {
-        T::ty() | Type::nil()
-    }
-
-    fn as_param() -> Type {
-        T::as_param() | Type::nil()
-    }
-
-    fn as_return() -> Type {
-        T::as_return() | Type::nil()
-    }
-}
-
-impl<T: IntoLuaTypeLiteral> From<T> for Type {
-    fn from(value: T) -> Self {
-        Type::Single(value.into_lua_type_literal().into())
-    }
-}
-
-impl<T: Typed> Typed for Arc<T> {
-    fn ty() -> Type {
-        T::ty()
-    }
-}
-
-impl<T: Typed> Typed for Rc<T> {
-    fn ty() -> Type {
-        T::ty()
-    }
-}
-
-impl<T: Typed> Typed for Cell<T> {
-    fn ty() -> Type {
-        T::ty()
-    }
-}
-
-impl<T: Typed> Typed for RefCell<T> {
-    fn ty() -> Type {
-        T::ty()
-    }
-}
-
-impl<T: Typed> Typed for Mutex<T> {
-    fn ty() -> Type {
-        T::ty()
-    }
-}
-
-impl<T: Typed> Typed for PhantomData<T> {
-    fn ty() -> Type {
-        T::ty()
-    }
-}
-
-// Represents a lua tuple.
-//
-// With luaCATS tuples are represented with square brackets.
-//
-// # Example
-//
-// ```lua
-// --- @type [string, integer, "literal"]
-// ```
-impl<const N: usize> From<[Type; N]> for Type {
-    fn from(value: [Type; N]) -> Self {
-        Type::Tuple(Vec::from(value))
-    }
-}
-
-// Array type
-
-impl<I: Typed, const N: usize> Typed for [I; N] {
-    fn ty() -> Type {
-        Type::Array(I::ty().into())
-    }
-}
-
-impl<I: Typed> Typed for Vec<I> {
-    fn ty() -> Type {
-        Type::Array(I::ty().into())
-    }
-}
-
-impl<I: Typed> Typed for &[I] {
-    fn ty() -> Type {
-        Type::Array(I::ty().into())
-    }
-}
-
-impl<I: Typed> Typed for HashSet<I> {
-    fn ty() -> Type {
-        Type::Array(I::ty().into())
-    }
-}
-
-impl<I: Typed> Typed for BTreeSet<I> {
-    fn ty() -> Type {
-        Type::Array(I::ty().into())
-    }
-}
-
-// Map type
-
-impl<K, V> Typed for BTreeMap<K, V>
-where
-    K: Typed,
-    V: Typed,
-{
-    fn ty() -> Type {
-        Type::Map(K::ty().into(), V::ty().into())
-    }
-}
-
-impl<K, V> Typed for HashMap<K, V>
-where
-    K: Typed,
-    V: Typed,
-{
-    fn ty() -> Type {
-        Type::Map(K::ty().into(), V::ty().into())
-    }
-}
 
 /// Represents a lua table key
 ///
@@ -643,6 +414,357 @@ impl_type_literal! {
     f32, f64
 }
 impl_type_literal! {bool}
+
+/// Add a lua [`Type`] representation to a rust type
+pub trait Typed {
+    /// Get the type representation
+    fn ty() -> Type;
+
+    #[inline(always)]
+    fn implicit() -> impl IntoIterator<Item = (&'static str, Type)> {
+        []
+    }
+
+    /// Get the type as a function parameter
+    fn as_param() -> Type {
+        Self::ty()
+    }
+
+    /// Get the type as a function return
+    fn as_return() -> Type {
+        Self::ty()
+    }
+}
+
+#[macro_export]
+macro_rules! join_types {
+    ($($ty:expr),+) => {
+        $crate::typed::Type::union([
+            $($crate::typed::Type::from($ty),)+
+        ])
+    };
+}
+
+macro_rules! impl_static_typed {
+    {
+        $(
+            $($target: ty)|*
+            => $name: literal),*
+            $(,)?
+    } => {
+        $(
+            $(
+                impl Typed for $target {
+                    fn ty() -> Type {
+                        Type::named($name)
+                    }
+                }
+            )*
+        )*
+    };
+}
+
+macro_rules! impl_static_typed_generic {
+    {
+        $(
+            $(for<$($lt: lifetime),+> $target: ty)|*
+            => $name: literal),*
+            $(,)?
+    } => {
+        $(
+            $(
+                impl<$($lt,)+> Typed for $target {
+                    fn ty() -> Type {
+                        Type::named($name)
+                    }
+                }
+            )*
+        )*
+    };
+}
+
+impl_static_typed! {
+    mlua::LightUserData => "lightuserdata",
+    mlua::Error => "error",
+    String | &str => "string",
+    u8 | u16 | u32 | u64 | usize | u128 | i8 | i16 | i32 | i64 | isize | i128 => "integer",
+    f32 | f64 => "number",
+    bool => "boolean",
+
+    mlua::Function => "fun()",
+    mlua::Table => "table",
+    mlua::AnyUserData => "userdata",
+    mlua::String => "string",
+    mlua::Thread => "thread",
+}
+
+impl_static_typed_generic! {
+    for<'a> Cow<'a, str> => "string",
+}
+
+impl Typed for mlua::Value {
+    fn ty() -> Type {
+        Type::Single("any".into())
+    }
+}
+
+impl<T: Typed> Typed for Variadic<T> {
+    /// ...type
+    fn ty() -> Type {
+        Type::any()
+    }
+}
+
+impl<T: IntoLuaTypeLiteral> From<T> for Type {
+    fn from(value: T) -> Self {
+        Type::Single(value.into_lua_type_literal().into())
+    }
+}
+
+/// {type} | nil
+impl<T: Typed> Typed for Option<T> {
+    fn ty() -> Type {
+        T::ty() | Type::nil()
+    }
+
+    fn as_param() -> Type {
+        T::as_param() | Type::nil()
+    }
+
+    fn as_return() -> Type {
+        T::as_return() | Type::nil()
+    }
+}
+
+impl<T: Typed> Typed for Box<T> {
+    fn ty() -> Type {
+        T::ty()
+    }
+
+    fn as_param() -> Type {
+        T::as_param()
+    }
+
+    fn as_return() -> Type {
+        T::as_return()
+    }
+}
+
+impl<T: Typed> Typed for PhantomData<T> {
+    fn ty() -> Type {
+        T::ty()
+    }
+
+    fn as_param() -> Type {
+        T::as_param()
+    }
+
+    fn as_return() -> Type {
+        T::as_return()
+    }
+}
+
+// Represents a lua tuple.
+//
+// With luaCATS tuples are represented with square brackets.
+//
+// # Example
+//
+// ```lua
+// --- @type [string, integer, "literal"]
+// ```
+impl<const N: usize> From<[Type; N]> for Type {
+    fn from(value: [Type; N]) -> Self {
+        Type::Tuple(Vec::from(value))
+    }
+}
+
+// Array type
+
+impl<I: Typed, const N: usize> Typed for [I; N] {
+    fn ty() -> Type {
+        Type::Array(I::ty().into())
+    }
+
+    fn as_param() -> Type {
+        Type::Array(I::as_param().into())
+    }
+
+    fn as_return() -> Type {
+        Type::Array(I::as_return().into())
+    }
+}
+
+impl<I: Typed> Typed for Vec<I> {
+    fn ty() -> Type {
+        Type::Array(I::ty().into())
+    }
+
+    fn as_param() -> Type {
+        Type::Array(I::as_param().into())
+    }
+
+    fn as_return() -> Type {
+        Type::Array(I::as_return().into())
+    }
+}
+
+impl<I: Typed> Typed for &[I] {
+    fn ty() -> Type {
+        Type::Array(I::ty().into())
+    }
+
+    fn as_param() -> Type {
+        Type::Array(I::as_param().into())
+    }
+
+    fn as_return() -> Type {
+        Type::Array(I::as_return().into())
+    }
+}
+
+impl<I: Typed> Typed for HashSet<I> {
+    fn ty() -> Type {
+        Type::Array(I::ty().into())
+    }
+
+    fn as_param() -> Type {
+        Type::Array(I::as_param().into())
+    }
+
+    fn as_return() -> Type {
+        Type::Array(I::as_return().into())
+    }
+}
+
+impl<I: Typed> Typed for BTreeSet<I> {
+    fn ty() -> Type {
+        Type::Array(I::ty().into())
+    }
+
+    fn as_param() -> Type {
+        Type::Array(I::as_param().into())
+    }
+
+    fn as_return() -> Type {
+        Type::Array(I::as_return().into())
+    }
+}
+
+// Map type
+
+impl<K, V> Typed for BTreeMap<K, V>
+where
+    K: Typed,
+    V: Typed,
+{
+    fn ty() -> Type {
+        Type::Map(K::ty().into(), V::ty().into())
+    }
+
+    fn as_param() -> Type {
+        Type::Map(K::as_param().into(), V::as_param().into())
+    }
+
+    fn as_return() -> Type {
+        Type::Map(K::as_return().into(), V::as_return().into())
+    }
+}
+
+impl<K, V> Typed for HashMap<K, V>
+where
+    K: Typed,
+    V: Typed,
+{
+    fn ty() -> Type {
+        Type::Map(K::ty().into(), V::ty().into())
+    }
+
+    fn as_param() -> Type {
+        Type::Map(K::as_param().into(), V::as_param().into())
+    }
+
+    fn as_return() -> Type {
+        Type::Map(K::as_return().into(), V::as_return().into())
+    }
+}
+
+// External Types
+
+#[cfg(feature="userdata-wrappers")]
+impl<T: Typed> Typed for Arc<T> {
+    fn ty() -> Type {
+        T::ty()
+    }
+
+    fn as_param() -> Type {
+        T::as_param()
+    }
+
+    fn as_return() -> Type {
+        T::as_return()
+    }
+}
+
+#[cfg(feature="userdata-wrappers")]
+impl<T: Typed> Typed for Rc<T> {
+    fn ty() -> Type {
+        T::ty()
+    }
+
+    fn as_param() -> Type {
+        T::as_param()
+    }
+
+    fn as_return() -> Type {
+        T::as_return()
+    }
+}
+
+#[cfg(feature="userdata-wrappers")]
+impl<T: Typed> Typed for Cell<T> {
+    fn ty() -> Type {
+        T::ty()
+    }
+
+    fn as_param() -> Type {
+        T::as_param()
+    }
+
+    fn as_return() -> Type {
+        T::as_return()
+    }
+}
+
+#[cfg(feature="userdata-wrappers")]
+impl<T: Typed> Typed for RefCell<T> {
+    fn ty() -> Type {
+        T::ty()
+    }
+
+    fn as_param() -> Type {
+        T::as_param()
+    }
+
+    fn as_return() -> Type {
+        T::as_return()
+    }
+}
+
+#[cfg(feature="userdata-wrappers")]
+impl<T: Typed> Typed for Mutex<T> {
+    fn ty() -> Type {
+        T::ty()
+    }
+
+    fn as_param() -> Type {
+        T::as_param()
+    }
+
+    fn as_return() -> Type {
+        T::as_return()
+    }
+}
 
 /// Typed information for a lua [`MultiValue`][mlua::MultiValue]
 pub trait TypedMultiValue {

--- a/tests/recursive.rs
+++ b/tests/recursive.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "mlua", feature = "derive"))]
+#![cfg(all(feature = "mlua", feature = "macros"))]
 
 use mlua::{FromLua, MetaMethod, UserData, Value};
 use mlua_extras::{
@@ -64,6 +64,29 @@ impl TypedUserData for TestOption {
                 })
             },
         );
+        
+        #[cfg(feature="userdata-wrappers")]
+        methods.add_function(
+            "func_returns_arc_self",
+            |_, ()| -> mlua::Result<std::sync::Arc<Self>> { Ok(Default::default()) },
+        );
+        #[cfg(feature="userdata-wrappers")]
+        methods.add_function(
+            "func_returns_arc_mutex_self",
+            |_, ()| -> mlua::Result<std::sync::Arc<std::sync::Mutex<Self>>> { Ok(Default::default()) },
+        );
+
+        #[cfg(feature="userdata-wrappers")]
+        methods.add_function(
+            "func_returns_rc_refcell_self",
+            |_, ()| -> mlua::Result<std::rc::Rc<Self>> { Ok(Default::default()) },
+        );
+        #[cfg(feature="userdata-wrappers")]
+        methods.add_function(
+            "func_returns_rc_refcell_self",
+            |_, ()| -> mlua::Result<std::rc::Rc<std::cell::RefCell<Self>>> { Ok(Default::default()) },
+        );
+
 
         methods.add_method("clone", |_, this, ()| Ok(this.clone()));
         methods.add_method(

--- a/tests/user_data.rs
+++ b/tests/user_data.rs
@@ -1,4 +1,4 @@
-#![cfg(all(feature = "mlua", feature = "derive"))]
+#![cfg(all(feature = "mlua", feature = "macros"))]
 
 use mlua::{AnyUserData, FromLua};
 use mlua_extras::{


### PR DESCRIPTION
Calling incorrect Typed impl functions could lead to infinite loops while building type information. Correct this in the wrapper types and put them behind the correct feature flag like mlua does