### PR TITLE
Check formatting in pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,16 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  format:
+    name: format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - run: cargo fmt --check
+
   test:
     # Run the tests in each of the feature combinations.
     # This is not an exhaustive test of all possible combinations,

--- a/examples/macros.rs
+++ b/examples/macros.rs
@@ -10,7 +10,9 @@ use mlua_extras::{
 
 /// Simple Counter
 #[derive(Clone, TypedUserData)]
-struct Counter { value: i64 }
+struct Counter {
+    value: i64,
+}
 
 #[typed_user_data_impl]
 impl Counter {
@@ -42,11 +44,15 @@ impl Counter {
 
     /// Get the current counter value
     #[method]
-    fn get(&self) -> i64 { self.value }
+    fn get(&self) -> i64 {
+        self.value
+    }
 
     /// Increment the counter
     #[method]
-    fn increment(&mut self) { self.value += 1 }
+    fn increment(&mut self) {
+        self.value += 1
+    }
 
     /// Create a new table
     #[method]
@@ -56,7 +62,9 @@ impl Counter {
 
     /// String representation of the counter
     #[metamethod(ToString)]
-    fn to_string(&self) -> String { format!("Counter({})", self.value) }
+    fn to_string(&self) -> String {
+        format!("Counter({})", self.value)
+    }
 
     // Requires the `async` feature
     // Must be accessed from lua code with an entry of `mlua::Chunk::eval_async` or `mlua::Chunk::exec_async`
@@ -71,11 +79,7 @@ impl Counter {
 
 fn main() -> mlua::Result<()> {
     let definitions: Definitions = Definitions::start()
-        .define(
-            "macros",
-            Definition::start()
-                .register::<Counter>("Counter")
-        )
+        .define("macros", Definition::start().register::<Counter>("Counter"))
         .finish();
 
     let types_path = PathBuf::from("examples/types");

--- a/examples/path.rs
+++ b/examples/path.rs
@@ -23,10 +23,13 @@ fn main() -> mlua::Result<()> {
     lua.append_cpath(PathBuf::from("examples").join("?.dll"))?;
     lua.append_cpath(PathBuf::from("examples").join("?.lib"))?;
 
-    lua.load(r#"
+    lua.load(
+        r#"
     print(package.path, '\n')
     print(package.cpath, '\n')
-    "#).eval::<()>()?;
+    "#,
+    )
+    .eval::<()>()?;
 
     // Set globals in with shorthand helpers
     lua.set_global("key", "value")?;

--- a/examples/typed.rs
+++ b/examples/typed.rs
@@ -1,15 +1,15 @@
 use std::path::PathBuf;
 
 use mlua_extras::{
+    Typed, UserData,
     extras::LuaExtras,
     mlua::{self, FromLua, Lua, LuaSerdeExt, MetaMethod, Value, Variadic},
     typed::{
+        Type, TypedDataFields, TypedDataMethods, TypedUserData,
         generator::{
             Definition, DefinitionFileGenerator, Definitions, LuauDefinitionFileGenerator,
         },
-        Type, TypedDataFields, TypedDataMethods, TypedUserData,
     },
-    Typed, UserData,
 };
 use serde::Deserialize;
 

--- a/src/extras/mod.rs
+++ b/src/extras/mod.rs
@@ -4,7 +4,7 @@ use mlua::{AnyUserData, FromLua, FromLuaMulti, IntoLua, IntoLuaMulti, Lua, Table
 
 mod module;
 
-pub use module::{LuaModule, Module, ModuleBuilder, ModuleFields, ModuleMethods, ExtendModule};
+pub use module::{ExtendModule, LuaModule, Module, ModuleBuilder, ModuleFields, ModuleMethods};
 
 use crate::MaybeSend;
 
@@ -46,7 +46,7 @@ pub trait LuaExtras {
     ///   - <https://www.lua.org/manual/5.4/manual.html#pdf-package.path>
     ///   - <https://www.lua.org/manual/5.4/manual.html#pdf-package.searchpath>
     fn prepend_paths<S: AsRef<Path>>(&self, paths: impl IntoIterator<Item = S>)
-        -> mlua::Result<()>;
+    -> mlua::Result<()>;
 
     /// Append a path tothe `package.path` value
     ///
@@ -114,7 +114,7 @@ pub trait LuaExtras {
     ///   - <https://www.lua.org/manual/5.4/manual.html#pdf-package.cpath>
     ///   - <https://www.lua.org/manual/5.4/manual.html#pdf-package.searchpath>
     fn append_cpaths<S: AsRef<Path>>(&self, paths: impl IntoIterator<Item = S>)
-        -> mlua::Result<()>;
+    -> mlua::Result<()>;
 
     /// Set the `package.cpath` value
     ///

--- a/src/extras/module.rs
+++ b/src/extras/module.rs
@@ -55,7 +55,7 @@ pub trait Module: Sized {
     fn add_fields<F: ModuleFields>(fields: &mut F) -> mlua::Result<()> {
         Ok(())
     }
-    
+
     /// Add methods/functions to the module
     #[allow(unused_variables)]
     fn add_methods<M: ModuleMethods>(methods: &mut M) -> mlua::Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,17 @@
 pub mod ser;
 
-#[cfg(feature="mlua")]
-pub mod typed;
-#[cfg(feature="mlua")]
+#[cfg(feature = "mlua")]
 pub mod extras;
+#[cfg(feature = "mlua")]
+pub mod typed;
 
-#[cfg(feature="mlua")]
+#[cfg(feature = "mlua")]
 pub use mlua;
 
-#[cfg(feature="macros")]
-pub use mlua_extras_derive::{UserData, user_data_impl, Typed, TypedUserData, typed_user_data_impl};
+#[cfg(feature = "macros")]
+pub use mlua_extras_derive::{
+    Typed, TypedUserData, UserData, typed_user_data_impl, user_data_impl,
+};
 
 #[cfg(feature = "send")]
 /// Used by the `send` feature

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -78,7 +78,7 @@ impl<'a, 'b> Serializer for &'a mut LuaSerializer<'b> {
         if v.is_nan() {
             self.out.push_str("0/0");
         } else if v.is_infinite() {
-            if  v.is_sign_positive() {
+            if v.is_sign_positive() {
                 self.out.push_str("math.huge");
             } else {
                 self.out.push_str("-math.huge");
@@ -106,7 +106,7 @@ impl<'a, 'b> Serializer for &'a mut LuaSerializer<'b> {
             if v.is_nan() {
                 self.out.push_str("0/0");
             } else if v.is_infinite() {
-                if  v.is_sign_positive() {
+                if v.is_sign_positive() {
                     self.out.push_str("math.huge");
                 } else {
                     self.out.push_str("-math.huge");

--- a/src/typed/class/mod.rs
+++ b/src/typed/class/mod.rs
@@ -4,13 +4,13 @@ use mlua::{UserDataRef, UserDataRefMut};
 
 use crate::{MaybeSend, typed::IntoDocComment};
 
-use super::{Typed, TypedMultiValue, Type};
+use super::{Type, Typed, TypedMultiValue};
 
-mod wrapped;
 mod standard;
+mod wrapped;
 
+pub use standard::{TypedClass, TypedClassBuilder};
 pub use wrapped::WrappedBuilder;
-pub use standard::{TypedClassBuilder, TypedClass};
 
 /// Typed variant of [`mlua::UserData`]
 pub trait TypedUserData: Sized {
@@ -136,24 +136,29 @@ pub trait TypedDataMethods<T> {
     fn document(&mut self, doc: impl IntoDocComment) -> &mut Self;
 
     /// Adds a param name and doc comment to the next method/function that gets added.
-    /// 
+    ///
     /// These will be applied to the params in the order they were defined.
     fn param(&mut self, name: impl std::fmt::Display, doc: impl IntoDocComment) -> &mut Self;
 
     /// Adds a param name and doc comment to the next method/function that gets added.
     /// Will also add an override type to the param.
-    /// 
+    ///
     /// These will be applied to the params in the order they were defined.
-    fn param_as(&mut self, ty: impl Into<Type>, name: impl std::fmt::Display, doc: impl IntoDocComment) -> &mut Self;
+    fn param_as(
+        &mut self,
+        ty: impl Into<Type>,
+        name: impl std::fmt::Display,
+        doc: impl IntoDocComment,
+    ) -> &mut Self;
 
     /// Adds a return doc comment to the next method/function that gets added.
-    /// 
+    ///
     /// These will be applied to the returns in the order they were defined.
     fn ret(&mut self, doc: impl IntoDocComment) -> &mut Self;
-    
+
     /// Adds a return doc comment to the next method/function that gets added.
     /// Will also add an override type to the return.
-    /// 
+    ///
     /// These will be applied to the returns in the order they were defined.
     fn ret_as(&mut self, ty: impl Into<Type>, doc: impl IntoDocComment) -> &mut Self;
 
@@ -170,7 +175,7 @@ pub trait TypedDataFields<T> {
     fn document(&mut self, doc: impl IntoDocComment) -> &mut Self;
 
     /// Adds a type to the queued overrides.
-    /// 
+    ///
     /// It will be used on the next field and will override the type that is automatically used.
     fn coerce(&mut self, ty: impl Into<Type>) -> &mut Self;
 
@@ -199,8 +204,8 @@ pub trait TypedDataFields<T> {
         S: Into<String>,
         R: IntoLua + Typed,
         A: FromLua + Typed,
-        GET: 'static + MaybeSend + Fn(& Lua, &T) -> mlua::Result<R>,
-        SET: 'static + MaybeSend + Fn(& Lua, &mut T, A) -> mlua::Result<()>;
+        GET: 'static + MaybeSend + Fn(&Lua, &T) -> mlua::Result<R>,
+        SET: 'static + MaybeSend + Fn(&Lua, &mut T, A) -> mlua::Result<()>;
 
     /// Typed version of [add_field_function_get](mlua::UserDataFields::add_field_function_get)
     fn add_field_function_get<S, R, F>(&mut self, name: S, function: F)
@@ -227,7 +232,8 @@ pub trait TypedDataFields<T> {
 
     /// Typed version of [add_meta_field](mlua::UserDataFields::add_meta_field)
     fn add_meta_field<V>(&mut self, meta: impl Into<String>, value: V)
-    where V: IntoLua + Typed + 'static;
+    where
+        V: IntoLua + Typed + 'static;
 
     /// Typed version of [add_meta_field](mlua::UserDataFields::add_meta_field_with)
     fn add_meta_field_with<R, F>(&mut self, meta: impl Into<String>, f: F)

--- a/src/typed/class/standard.rs
+++ b/src/typed/class/standard.rs
@@ -3,7 +3,9 @@ use std::{borrow::Cow, collections::BTreeMap};
 use mlua::{AnyUserData, FromLua, FromLuaMulti, IntoLua, IntoLuaMulti, Lua};
 
 use crate::{
-    MaybeSend, ser::to_lua_repr, typed::{Field, Func, Index, IntoDocComment, StaticField, Type}
+    MaybeSend,
+    ser::to_lua_repr,
+    typed::{Field, Func, Index, IntoDocComment, StaticField, Type},
 };
 
 use super::{
@@ -115,27 +117,38 @@ impl TypedClassBuilder {
     ///     .field("message", Type::string(), format!("A message for {NAME}"));
     /// ```
     pub fn field(mut self, key: impl Into<Index>, ty: Type, doc: impl IntoDocComment) -> Self {
-        self.typed_class.fields.insert(key.into(), Field::new(ty, doc));
+        self.typed_class
+            .fields
+            .insert(key.into(), Field::new(ty, doc));
         self
     }
 
-    pub fn static_field<V>(mut self, key: impl Into<Index>, value: V, doc: impl IntoDocComment) -> Self 
+    pub fn static_field<V>(
+        mut self,
+        key: impl Into<Index>,
+        value: V,
+        doc: impl IntoDocComment,
+    ) -> Self
     where
-        V: Typed + IntoLua
+        V: Typed + IntoLua,
     {
         let value = match value.into_lua(&self.lua) {
             Ok(value) => to_lua_repr(&value).map_err(mlua::Error::runtime),
-            Err(err) => Err(err)
+            Err(err) => Err(err),
         };
 
         if let Ok(value) = value {
-            self.typed_class.static_fields.insert(key.into(), StaticField::new(V::ty(), doc, value));
+            self.typed_class
+                .static_fields
+                .insert(key.into(), StaticField::new(V::ty(), doc, value));
         }
         self
     }
 
     pub fn inherit(mut self, parent: &TypedClass) -> Self {
-        self.typed_class.static_fields.extend(parent.static_fields.clone());
+        self.typed_class
+            .static_fields
+            .extend(parent.static_fields.clone());
         self
     }
 
@@ -221,7 +234,9 @@ impl TypedClassBuilder {
     ///     .meta_field("message", Type::string(), format!("A message for {NAME}"));
     /// ```
     pub fn meta_field(mut self, key: impl Into<Index>, ty: Type, doc: impl IntoDocComment) -> Self {
-        self.typed_class.meta_fields.insert(key.into(), Field::new(ty, doc));
+        self.typed_class
+            .meta_fields
+            .insert(key.into(), Field::new(ty, doc));
         self
     }
 
@@ -329,7 +344,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
     {
         let value = match value.into_lua(&self.lua) {
             Ok(value) => to_lua_repr(&value).map_err(mlua::Error::runtime),
-            Err(err) => Err(err)
+            Err(err) => Err(err),
         };
 
         if let Ok(value) = value {
@@ -337,15 +352,10 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
             let ty = self.queued_ty.take().unwrap_or(V::as_param());
             let value: Cow<'static, str> = value.into();
 
-            self.typed_class.static_fields
-                .insert(
-                    name.into(),
-                    StaticField::new(
-                        ty,
-                        self.queued_doc.take(),
-                        value,
-                    )
-                );
+            self.typed_class.static_fields.insert(
+                name.into(),
+                StaticField::new(ty, self.queued_doc.take(), value),
+            );
         }
     }
 
@@ -357,7 +367,8 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
     {
         let name: Cow<'static, str> = name.into().into();
         let ty = self.queued_ty.take().unwrap_or(A::as_param());
-        self.typed_class.fields
+        self.typed_class
+            .fields
             .entry(name.into())
             .and_modify({
                 let ty = ty.clone();
@@ -365,7 +376,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
                     if let Some(doc) = self.queued_doc.take() {
                         v.doc = Some(match v.doc.take() {
                             Some(d) => format!("{d}\n{doc}").into(),
-                            None => doc
+                            None => doc,
                         });
                     }
                     v.ty = v.ty.clone() | ty;
@@ -385,7 +396,8 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
     {
         let name: Cow<'static, str> = name.into().into();
         let ty = self.queued_ty.take().unwrap_or(R::as_return());
-        self.typed_class.fields
+        self.typed_class
+            .fields
             .entry(name.into())
             .and_modify({
                 let ty = ty.clone();
@@ -393,7 +405,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
                     if let Some(doc) = self.queued_doc.take() {
                         v.doc = Some(match v.doc.take() {
                             Some(d) => format!("{d}\n{doc}").into(),
-                            None => doc
+                            None => doc,
                         });
                     }
                     v.ty = v.ty.clone() | ty;
@@ -414,8 +426,12 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
         SET: 'static + MaybeSend + Fn(&Lua, AnyUserData, A) -> mlua::Result<()>,
     {
         let name: Cow<'static, str> = name.into().into();
-        let ty = self.queued_ty.take().unwrap_or(A::as_param() | R::as_return());
-        self.typed_class.fields
+        let ty = self
+            .queued_ty
+            .take()
+            .unwrap_or(A::as_param() | R::as_return());
+        self.typed_class
+            .fields
             .entry(name.into())
             .and_modify({
                 let ty = ty.clone();
@@ -423,7 +439,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
                     if let Some(doc) = self.queued_doc.take() {
                         v.doc = Some(match v.doc.take() {
                             Some(d) => format!("{d}\n{doc}").into(),
-                            None => doc
+                            None => doc,
                         });
                     }
                     v.ty = v.ty.clone() | ty;
@@ -443,7 +459,8 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
     {
         let name: Cow<'static, str> = name.into().into();
         let ty = self.queued_ty.take().unwrap_or(A::as_param());
-        self.typed_class.fields
+        self.typed_class
+            .fields
             .entry(name.into())
             .and_modify({
                 let ty = ty.clone();
@@ -451,7 +468,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
                     if let Some(doc) = self.queued_doc.take() {
                         v.doc = Some(match v.doc.take() {
                             Some(d) => format!("{d}\n{doc}").into(),
-                            None => doc
+                            None => doc,
                         });
                     }
                     v.ty = v.ty.clone() | ty;
@@ -471,7 +488,8 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
     {
         let name: Cow<'static, str> = name.into().into();
         let ty = self.queued_ty.take().unwrap_or(R::as_return());
-        self.typed_class.fields
+        self.typed_class
+            .fields
             .entry(name.into())
             .and_modify({
                 let ty = ty.clone();
@@ -479,7 +497,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
                     if let Some(doc) = self.queued_doc.take() {
                         v.doc = Some(match v.doc.take() {
                             Some(d) => format!("{d}\n{doc}").into(),
-                            None => doc
+                            None => doc,
                         });
                     }
                     v.ty = v.ty.clone() | ty;
@@ -500,8 +518,12 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
         SET: 'static + MaybeSend + Fn(&Lua, &mut T, A) -> mlua::Result<()>,
     {
         let name: Cow<'static, str> = name.into().into();
-        let ty = self.queued_ty.take().unwrap_or(A::as_param() | R::as_return());
-        self.typed_class.fields
+        let ty = self
+            .queued_ty
+            .take()
+            .unwrap_or(A::as_param() | R::as_return());
+        self.typed_class
+            .fields
             .entry(name.into())
             .and_modify({
                 let ty = ty.clone();
@@ -509,7 +531,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
                     if let Some(doc) = self.queued_doc.take() {
                         v.doc = Some(match v.doc.take() {
                             Some(d) => format!("{d}\n{doc}").into(),
-                            None => doc
+                            None => doc,
                         });
                     }
                     v.ty = v.ty.clone() | ty;
@@ -527,7 +549,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
     {
         let value = match value.into_lua(&self.lua) {
             Ok(value) => to_lua_repr(&value).map_err(mlua::Error::runtime),
-            Err(err) => Err(err)
+            Err(err) => Err(err),
         };
 
         if let Ok(value) = value {
@@ -535,26 +557,22 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
             let ty = self.queued_ty.take().unwrap_or(V::as_param());
             let value: Cow<'static, str> = value.into();
 
-            self.typed_class.static_meta_fields
-                .insert(
-                    name.into(),
-                    StaticField::new(
-                        ty,
-                        self.queued_doc.take(),
-                        value,
-                    )
-                );
+            self.typed_class.static_meta_fields.insert(
+                name.into(),
+                StaticField::new(ty, self.queued_doc.take(), value),
+            );
         }
     }
 
     fn add_meta_field_with<R, F>(&mut self, meta: impl Into<String>, _: F)
-        where
-            F: 'static + MaybeSend + Fn(&Lua) -> mlua::Result<R>,
-            R: IntoLua + Typed {
-
+    where
+        F: 'static + MaybeSend + Fn(&Lua) -> mlua::Result<R>,
+        R: IntoLua + Typed,
+    {
         let name: Cow<'static, str> = meta.into().into();
         let ty = self.queued_ty.take().unwrap_or(R::as_return());
-        self.typed_class.meta_fields
+        self.typed_class
+            .meta_fields
             .entry(name.into())
             .and_modify({
                 let ty = ty.clone();
@@ -562,7 +580,7 @@ impl<T: TypedUserData> TypedDataFields<T> for TypedClassBuilder {
                     if let Some(doc) = self.queued_doc.take() {
                         v.doc = Some(match v.doc.take() {
                             Some(d) => format!("{d}\n{doc}").into(),
-                            None => doc
+                            None => doc,
                         });
                     }
                     v.ty = v.ty.clone() | ty;
@@ -582,12 +600,19 @@ impl<T: TypedUserData> TypedDataMethods<T> for TypedClassBuilder {
     }
 
     fn param(&mut self, name: impl std::fmt::Display, doc: impl IntoDocComment) -> &mut Self {
-        self.queued_params.push((None, name.to_string(), doc.into_doc_comment()));
+        self.queued_params
+            .push((None, name.to_string(), doc.into_doc_comment()));
         self
     }
 
-    fn param_as(&mut self, ty: impl Into<Type>, name: impl std::fmt::Display, doc: impl IntoDocComment) -> &mut Self {
-        self.queued_params.push((Some(ty.into()), name.to_string(), doc.into_doc_comment()));
+    fn param_as(
+        &mut self,
+        ty: impl Into<Type>,
+        name: impl std::fmt::Display,
+        doc: impl IntoDocComment,
+    ) -> &mut Self {
+        self.queued_params
+            .push((Some(ty.into()), name.to_string(), doc.into_doc_comment()));
         self
     }
 
@@ -598,19 +623,31 @@ impl<T: TypedUserData> TypedDataMethods<T> for TypedClassBuilder {
         self
     }
 
-    
     fn ret_as(&mut self, ty: impl Into<Type>, doc: impl IntoDocComment) -> &mut Self {
-        self.queued_returns.push((Some(ty.into()), doc.into_doc_comment()));
+        self.queued_returns
+            .push((Some(ty.into()), doc.into_doc_comment()));
         self
     }
 
     fn index<I: Typed>(&mut self, idx: isize, doc: impl IntoDocComment) -> &mut Self {
-        self.typed_class.fields.insert(idx.into(), Field { ty: I::as_param(), doc: doc.into_doc_comment() });
+        self.typed_class.fields.insert(
+            idx.into(),
+            Field {
+                ty: I::as_param(),
+                doc: doc.into_doc_comment(),
+            },
+        );
         self
     }
 
     fn index_as(&mut self, idx: isize, ty: impl Into<Type>, doc: impl IntoDocComment) -> &mut Self {
-        self.typed_class.fields.insert(idx.into(), Field { ty: ty.into(), doc: doc.into_doc_comment() });
+        self.typed_class.fields.insert(
+            idx.into(),
+            Field {
+                ty: ty.into(),
+                doc: doc.into_doc_comment(),
+            },
+        );
         self
     }
 

--- a/src/typed/class/wrapped.rs
+++ b/src/typed/class/wrapped.rs
@@ -1,10 +1,10 @@
+use crate::{MaybeSend, typed::IntoDocComment};
 use mlua::{
-    AnyUserData, FromLua, FromLuaMulti, IntoLua, IntoLuaMulti, Lua, UserData,
-    UserDataFields, UserDataMethods,
+    AnyUserData, FromLua, FromLuaMulti, IntoLua, IntoLuaMulti, Lua, UserData, UserDataFields,
+    UserDataMethods,
 };
 #[cfg(feature = "async")]
 use mlua::{UserDataRef, UserDataRefMut};
-use crate::{MaybeSend, typed::IntoDocComment};
 
 use super::{Type, Typed, TypedDataFields, TypedDataMethods, TypedMultiValue};
 
@@ -104,9 +104,10 @@ impl<'ctx, T: UserData, U: UserDataFields<T>> TypedDataFields<T> for WrappedBuil
     }
 
     fn add_meta_field_with<R, F>(&mut self, name: impl Into<String>, f: F)
-        where
-            F: 'static + MaybeSend + Fn(&Lua) -> mlua::Result<R>,
-            R: IntoLua + 'static {
+    where
+        F: 'static + MaybeSend + Fn(&Lua) -> mlua::Result<R>,
+        R: IntoLua + 'static,
+    {
         self.0.add_meta_field_with(name, f);
     }
 }
@@ -116,14 +117,10 @@ impl<'ctx, T: UserData, U: UserDataMethods<T>> TypedDataMethods<T> for WrappedBu
         self
     }
 
-    fn param(
-        &mut self,
-        _name: impl std::fmt::Display,
-        _doc: impl IntoDocComment,
-    ) -> &mut Self {
+    fn param(&mut self, _name: impl std::fmt::Display, _doc: impl IntoDocComment) -> &mut Self {
         self
     }
-    
+
     fn param_as(
         &mut self,
         _ty: impl Into<Type>,
@@ -133,11 +130,10 @@ impl<'ctx, T: UserData, U: UserDataMethods<T>> TypedDataMethods<T> for WrappedBu
         self
     }
 
-
     fn ret(&mut self, _: impl IntoDocComment) -> &mut Self {
         self
     }
-    
+
     fn ret_as(&mut self, _: impl Into<Type>, _: impl IntoDocComment) -> &mut Self {
         self
     }
@@ -146,7 +142,12 @@ impl<'ctx, T: UserData, U: UserDataMethods<T>> TypedDataMethods<T> for WrappedBu
         self
     }
 
-    fn index_as(&mut self, _idx: isize, _ty: impl Into<Type>, _doc: impl IntoDocComment) -> &mut Self {
+    fn index_as(
+        &mut self,
+        _idx: isize,
+        _ty: impl Into<Type>,
+        _doc: impl IntoDocComment,
+    ) -> &mut Self {
         self
     }
 
@@ -252,7 +253,7 @@ impl<'ctx, T: UserData, U: UserDataMethods<T>> TypedDataMethods<T> for WrappedBu
     {
         self.0.add_meta_method_mut(meta, method)
     }
-    
+
     fn add_meta_function_mut<A, R, F>(&mut self, meta: impl Into<String>, function: F)
     where
         A: FromLuaMulti + TypedMultiValue,
@@ -278,17 +279,16 @@ mod tests {
 
     impl TypedUserData for Counter {
         fn add_methods<T: TypedDataMethods<Self>>(methods: &mut T) {
-            methods.add_async_method("get_value", |_lua, this, _: ()| async move {
-                Ok(this.value)
-            });
+            methods.add_async_method(
+                "get_value",
+                |_lua, this, _: ()| async move { Ok(this.value) },
+            );
         }
     }
 
     #[test]
     fn test_add_async_method_compiles() {
         let lua = Lua::new();
-        lua.globals()
-            .set("counter", Counter { value: 42 })
-            .unwrap();
+        lua.globals().set("counter", Counter { value: 42 }).unwrap();
     }
 }

--- a/src/typed/function.rs
+++ b/src/typed/function.rs
@@ -20,7 +20,9 @@ impl Param {
     /// Set the parameters name
     pub fn name(&mut self, name: impl Into<Cow<'static, str>>) -> &mut Self {
         let name = name.into();
-        if name.trim().is_empty() { return self; }
+        if name.trim().is_empty() {
+            return self;
+        }
         self.name = Some(name);
         self
     }
@@ -83,10 +85,7 @@ impl From<Type> for Param {
 /// Used to purely get function type information without converting it to anything
 /// else.
 pub trait IntoTypedFunction<Params: TypedMultiValue, Response: TypedMultiValue> {
-    fn into_typed_function(
-        self,
-        lua: &Lua,
-    ) -> mlua::Result<TypedFunction<Params, Response>>;
+    fn into_typed_function(self, lua: &Lua) -> mlua::Result<TypedFunction<Params, Response>>;
 }
 
 impl<F, Params, Response> IntoTypedFunction<Params, Response> for F
@@ -95,10 +94,7 @@ where
     Response: TypedMultiValue + IntoLuaMulti,
     F: Fn(&Lua, Params) -> mlua::Result<Response> + MaybeSend + 'static,
 {
-    fn into_typed_function(
-        self,
-        lua: &Lua,
-    ) -> mlua::Result<TypedFunction<Params, Response>> {
+    fn into_typed_function(self, lua: &Lua) -> mlua::Result<TypedFunction<Params, Response>> {
         Ok(TypedFunction {
             inner: lua.create_function(self)?,
             _p: PhantomData,
@@ -112,10 +108,7 @@ where
     Params: TypedMultiValue + FromLuaMulti,
     Response: TypedMultiValue + IntoLuaMulti,
 {
-    fn into_typed_function(
-        self,
-        _lua: &Lua,
-    ) -> mlua::Result<TypedFunction<Params, Response>> {
+    fn into_typed_function(self, _lua: &Lua) -> mlua::Result<TypedFunction<Params, Response>> {
         Ok(TypedFunction {
             inner: self,
             _p: PhantomData,
@@ -124,16 +117,12 @@ where
     }
 }
 
-impl<Params, Response> IntoTypedFunction<Params, Response>
-    for &TypedFunction<Params, Response>
+impl<Params, Response> IntoTypedFunction<Params, Response> for &TypedFunction<Params, Response>
 where
     Params: TypedMultiValue + FromLuaMulti,
     Response: TypedMultiValue + IntoLuaMulti,
 {
-    fn into_typed_function(
-        self,
-        _lua: &Lua,
-    ) -> mlua::Result<TypedFunction<Params, Response>> {
+    fn into_typed_function(self, _lua: &Lua) -> mlua::Result<TypedFunction<Params, Response>> {
         Ok(TypedFunction {
             inner: self.inner.clone(),
             _p: PhantomData,
@@ -147,10 +136,7 @@ where
     Params: TypedMultiValue + FromLuaMulti,
     Response: TypedMultiValue + IntoLuaMulti,
 {
-    fn into_typed_function(
-        self,
-        lua: &Lua,
-    ) -> mlua::Result<TypedFunction<Params, Response>> {
+    fn into_typed_function(self, lua: &Lua) -> mlua::Result<TypedFunction<Params, Response>> {
         Ok(TypedFunction {
             inner: lua.create_function(|_, _: Params| Ok(()))?,
             _p: PhantomData,
@@ -229,7 +215,7 @@ where
     Params: TypedMultiValue,
     Response: TypedMultiValue,
 {
-    fn into_lua(self, _lua: &Lua) -> mlua::prelude::LuaResult<Value<>> {
+    fn into_lua(self, _lua: &Lua) -> mlua::prelude::LuaResult<Value> {
         Ok(Value::Function(self.inner))
     }
 }
@@ -242,7 +228,7 @@ where
     fn ty() -> Type {
         Type::Function {
             params: Params::get_types_as_params(),
-            returns: Response::get_types_as_returns()
+            returns: Response::get_types_as_returns(),
         }
     }
 }

--- a/src/typed/generator/luau_type_file.rs
+++ b/src/typed/generator/luau_type_file.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, collections::HashMap, path::Path, slice::Iter};
 
-use crate::typed::{function::Return, Param, Type};
+use crate::typed::{Param, Type, function::Return};
 
 use super::{Definition, Definitions};
 
@@ -130,22 +130,16 @@ impl<'writer> LuauDefinitionWriter<'writer> {
 
                     // Instance fields
                     for (name, field) in type_data.fields.iter() {
-                        if name.is_int() { continue; }
-                        self.write_doc_comments(
-                            &mut buffer,
-                            &[field.doc.as_deref()],
-                            "\t",
-                        )?;
+                        if name.is_int() {
+                            continue;
+                        }
+                        self.write_doc_comments(&mut buffer, &[field.doc.as_deref()], "\t")?;
                         writeln!(buffer, "\t{}: {}", name, self.type_signature(&field.ty)?)?;
                     }
 
                     // Methods (with self)
                     for (name, func) in type_data.methods.iter() {
-                        self.write_doc_comments(
-                            &mut buffer,
-                            &[func.doc.as_deref()],
-                            "\t",
-                        )?;
+                        self.write_doc_comments(&mut buffer, &[func.doc.as_deref()], "\t")?;
                         writeln!(
                             buffer,
                             "\tfunction {}(self{}{}): {}",
@@ -158,31 +152,15 @@ impl<'writer> LuauDefinitionWriter<'writer> {
 
                     // Meta fields
                     for (name, field) in type_data.meta_fields.iter() {
-                        self.write_doc_comments(
-                            &mut buffer,
-                            &[field.doc.as_deref()],
-                            "\t",
-                        )?;
+                        self.write_doc_comments(&mut buffer, &[field.doc.as_deref()], "\t")?;
                         writeln!(buffer, "\t{}: {}", name, self.type_signature(&field.ty)?)?;
                     }
 
                     // Meta methods (with self)
                     for (name, func) in type_data.meta_methods.iter() {
-                        self.write_doc_comments(
-                            &mut buffer,
-                            &[func.doc.as_deref()],
-                            "\t",
-                        )?;
-                        self.write_param_doc_comments(
-                            &mut buffer,
-                            &func.params,
-                            "\t"
-                        )?;
-                        self.write_return_doc_comments(
-                            &mut buffer,
-                            &func.returns,
-                            "\t"
-                        )?;
+                        self.write_doc_comments(&mut buffer, &[func.doc.as_deref()], "\t")?;
+                        self.write_param_doc_comments(&mut buffer, &func.params, "\t")?;
+                        self.write_return_doc_comments(&mut buffer, &func.returns, "\t")?;
                         writeln!(
                             buffer,
                             "\tfunction {}(self{}{}): {}",
@@ -201,7 +179,9 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                     //
                     // They are first declared themselves to give them richer type information.
                     // Then they are added to a global table declaration with `typeof()`.
-                    let static_fns: Vec<_> = type_data.functions.iter()
+                    let static_fns: Vec<_> = type_data
+                        .functions
+                        .iter()
                         .chain(type_data.meta_functions.iter())
                         .collect();
 
@@ -210,21 +190,9 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                     }
 
                     for (name, func) in static_fns.iter() {
-                        self.write_doc_comments(
-                            &mut buffer,
-                            &[func.doc.as_deref()],
-                            "",
-                        )?;
-                        self.write_param_doc_comments(
-                            &mut buffer,
-                            &func.params,
-                            ""
-                        )?;
-                        self.write_return_doc_comments(
-                            &mut buffer,
-                            &func.returns,
-                            ""
-                        )?;
+                        self.write_doc_comments(&mut buffer, &[func.doc.as_deref()], "")?;
+                        self.write_param_doc_comments(&mut buffer, &func.params, "")?;
+                        self.write_return_doc_comments(&mut buffer, &func.returns, "")?;
                         writeln!(
                             buffer,
                             "declare function {}_{name}({}): {}",
@@ -244,15 +212,16 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                                 &[field.inner.doc.as_deref()],
                                 "\t",
                             )?;
-                            writeln!(buffer, "\t{}: {},", name, self.type_signature(&field.inner.ty)?)?;
+                            writeln!(
+                                buffer,
+                                "\t{}: {},",
+                                name,
+                                self.type_signature(&field.inner.ty)?
+                            )?;
                         }
 
                         for (name, _func) in &static_fns {
-                            writeln!(
-                                buffer,
-                                "\t{name}: typeof({}_{name}),",
-                                definition.name,
-                            )?;
+                            writeln!(buffer, "\t{name}: typeof({}_{name}),", definition.name,)?;
                         }
                         writeln!(buffer, "}}")?;
                     }
@@ -262,11 +231,7 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                         .borrow_mut()
                         .insert(definition.ty.clone(), definition.name.clone());
 
-                    self.write_doc_comments(
-                        &mut buffer,
-                        &[definition.doc.as_deref()],
-                        "",
-                    )?;
+                    self.write_doc_comments(&mut buffer, &[definition.doc.as_deref()], "")?;
                     let type_strs = types
                         .iter()
                         .map(|v| self.type_signature(v))
@@ -279,11 +244,7 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                     )?;
                 }
                 Type::Alias(ty) => {
-                    self.write_doc_comments(
-                        &mut buffer,
-                        &[definition.doc.as_deref()],
-                        "",
-                    )?;
+                    self.write_doc_comments(&mut buffer, &[definition.doc.as_deref()], "")?;
                     writeln!(
                         buffer,
                         "export type {} = {}",
@@ -292,21 +253,9 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                     )?;
                 }
                 Type::Function { params, returns } => {
-                    self.write_doc_comments(
-                        &mut buffer,
-                        &[definition.doc.as_deref()],
-                        "",
-                    )?;
-                    self.write_param_doc_comments(
-                        &mut buffer,
-                        &params,
-                        ""
-                    )?;
-                    self.write_return_doc_comments(
-                        &mut buffer,
-                        &returns,
-                        ""
-                    )?;
+                    self.write_doc_comments(&mut buffer, &[definition.doc.as_deref()], "")?;
+                    self.write_param_doc_comments(&mut buffer, &params, "")?;
+                    self.write_return_doc_comments(&mut buffer, &returns, "")?;
                     writeln!(
                         buffer,
                         "declare function {}({}): {}",
@@ -319,7 +268,7 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                     return Err(mlua::Error::runtime(format!(
                         "invalid root level type: {:?}",
                         other
-                    )))
+                    )));
                 }
             }
         }
@@ -334,7 +283,7 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                 None => {
                     return Err(mlua::Error::runtime(
                         "missing enum type definition; make sure the type is registered before it is used",
-                    ))
+                    ));
                 }
             },
             Type::Class(_) => match self.name_map.borrow().get(ty) {
@@ -342,7 +291,7 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                 None => {
                     return Err(mlua::Error::runtime(
                         "missing class type definition; make sure the type is registered before it is used",
-                    ))
+                    ));
                 }
             },
             Type::Single(value) => {
@@ -402,7 +351,9 @@ impl<'writer> LuauDefinitionWriter<'writer> {
             Type::Union(types) => {
                 // Check for T | nil pattern and emit T? shorthand
                 if types.len() == 2 {
-                    let nil_pos = types.iter().position(|t| matches!(t, Type::Single(s) if s == "nil"));
+                    let nil_pos = types
+                        .iter()
+                        .position(|t| matches!(t, Type::Single(s) if s == "nil"));
                     if let Some(pos) = nil_pos {
                         let other = &types[1 - pos];
                         let sig = self.type_signature(other)?;
@@ -431,7 +382,7 @@ impl<'writer> LuauDefinitionWriter<'writer> {
                 return Err(mlua::Error::runtime(format!(
                     "type cannot be a type signature: {}",
                     other.as_ref()
-                )))
+                )));
             }
         })
     }
@@ -488,8 +439,13 @@ impl<'writer> LuauDefinitionWriter<'writer> {
         indent: &str,
     ) -> mlua::Result<()> {
         for (i, p) in params.iter().enumerate().filter(|(_, p)| p.doc.is_some()) {
-            write!(buffer, "{indent}-- @param {} {}",
-                p.name.as_deref().map(|v| v.to_string()).unwrap_or_else(|| format!("param{}", i + 1)),
+            write!(
+                buffer,
+                "{indent}-- @param {} {}",
+                p.name
+                    .as_deref()
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| format!("param{}", i + 1)),
                 self.type_signature(&p.ty)?
             )?;
             if let Some(doc) = p.doc.as_deref() {

--- a/src/typed/generator/mod.rs
+++ b/src/typed/generator/mod.rs
@@ -6,8 +6,8 @@ use std::{
 };
 
 use super::{
-    function::{IntoTypedFunction, Return},
     Param, Type, Typed, TypedMultiValue,
+    function::{IntoTypedFunction, Return},
 };
 
 mod type_file;
@@ -149,7 +149,7 @@ impl DefinitionBuilder {
                 self.queued_params.drain(..).collect(),
                 self.queued_returns.drain(..).collect(),
             ),
-            self.queued_doc.take()
+            self.queued_doc.take(),
         ));
         self
     }
@@ -240,7 +240,11 @@ impl DefinitionBuilder {
     /// example = nil
     /// ```
     pub fn value<T: Typed>(mut self, name: impl std::fmt::Display) -> Self {
-        self.entries.push(Entry::new_with(name, Type::Value(Box::new(T::ty())), self.queued_doc.take()));
+        self.entries.push(Entry::new_with(
+            name,
+            Type::Value(Box::new(T::ty())),
+            self.queued_doc.take(),
+        ));
         self
     }
 

--- a/src/typed/generator/type_file.rs
+++ b/src/typed/generator/type_file.rs
@@ -77,7 +77,10 @@ impl<'def> Iterator for DefinitionFileIter<'def> {
         self.definitions.next().map(|v| {
             (
                 format!("{}{}", v.0, self.extension),
-                DefinitionWriter { definition: &v.1, name_map: RefCell::new(HashMap::default()) },
+                DefinitionWriter {
+                    definition: &v.1,
+                    name_map: RefCell::new(HashMap::default()),
+                },
             )
         })
     }
@@ -114,11 +117,14 @@ impl<'writer> DefinitionWriter<'writer> {
                     writeln!(buffer, "{} = nil", definition.name)?;
                 }
                 Type::Class(type_data) => {
-                    self.name_map.borrow_mut().insert(definition.ty.clone(), definition.name.clone());
+                    self.name_map
+                        .borrow_mut()
+                        .insert(definition.ty.clone(), definition.name.clone());
 
-                    if let Some(docs) =
-                        self.accumulate_docs(&[definition.doc.as_deref(), type_data.type_doc.as_deref()])
-                    {
+                    if let Some(docs) = self.accumulate_docs(&[
+                        definition.doc.as_deref(),
+                        type_data.type_doc.as_deref(),
+                    ]) {
                         writeln!(buffer, "{}", docs.join("\n"))?;
                     }
                     write!(buffer, "--- @class {}", definition.name)?;
@@ -138,9 +144,20 @@ impl<'writer> DefinitionWriter<'writer> {
                         )?;
                     }
 
-                    if !type_data.static_fields.is_empty() || !type_data.functions.is_empty() || !type_data.methods.is_empty() || !type_data.is_meta_empty() {
+                    if !type_data.static_fields.is_empty()
+                        || !type_data.functions.is_empty()
+                        || !type_data.methods.is_empty()
+                        || !type_data.is_meta_empty()
+                    {
                         writeln!(buffer, "local _CLASS_{}_ = {{", definition.name)?;
-                        for (name, StaticField { inner: Field { doc, .. }, default }) in type_data.static_fields.iter() {
+                        for (
+                            name,
+                            StaticField {
+                                inner: Field { doc, .. },
+                                default,
+                            },
+                        ) in type_data.static_fields.iter()
+                        {
                             if let Some(docs) = self.accumulate_docs(&[doc.as_deref()]) {
                                 writeln!(buffer, "\t{}", docs.join("\n\t"))?;
                             }
@@ -154,13 +171,8 @@ impl<'writer> DefinitionWriter<'writer> {
                             writeln!(
                                 buffer,
                                 "\t{},",
-                                self.function_signature(
-                                    name,
-                                    &func.params,
-                                    &func.returns,
-                                    true
-                                )?
-                                .join("\n\t")
+                                self.function_signature(name, &func.params, &func.returns, true)?
+                                    .join("\n\t")
                             )?;
                         }
 
@@ -184,7 +196,14 @@ impl<'writer> DefinitionWriter<'writer> {
 
                         if !type_data.is_meta_empty() {
                             writeln!(buffer, "\t__metatable = {{")?;
-                            for (name, StaticField { inner: Field { ty, doc }, default }) in type_data.static_meta_fields.iter() {
+                            for (
+                                name,
+                                StaticField {
+                                    inner: Field { ty, doc },
+                                    default,
+                                },
+                            ) in type_data.static_meta_fields.iter()
+                            {
                                 if let Some(docs) = self.accumulate_docs(&[doc.as_deref()]) {
                                     writeln!(buffer, "\t\t{}", docs.join("\n\t\t"))?;
                                 }
@@ -197,7 +216,11 @@ impl<'writer> DefinitionWriter<'writer> {
                                 if let Some(docs) = self.accumulate_docs(&[field.doc.as_deref()]) {
                                     writeln!(buffer, "\t\t{}", docs.join("\n\t\t"))?;
                                 }
-                                writeln!(buffer, "\t\t--- @type {}", self.type_signature(&field.ty)?)?;
+                                writeln!(
+                                    buffer,
+                                    "\t\t--- @type {}",
+                                    self.type_signature(&field.ty)?
+                                )?;
                                 writeln!(buffer, "\t\t{name} = nil,")?;
                             }
 
@@ -241,7 +264,9 @@ impl<'writer> DefinitionWriter<'writer> {
                     }
                 }
                 Type::Enum(types) => {
-                    self.name_map.borrow_mut().insert(definition.ty.clone(), definition.name.clone());
+                    self.name_map
+                        .borrow_mut()
+                        .insert(definition.ty.clone(), definition.name.clone());
 
                     if let Some(docs) = self.accumulate_docs(&[definition.doc.as_deref()]) {
                         writeln!(buffer, "{}", docs.join("\n"))?;
@@ -288,7 +313,7 @@ impl<'writer> DefinitionWriter<'writer> {
                     return Err(mlua::Error::runtime(format!(
                         "invalid root level type: {:?}",
                         other
-                    )))
+                    )));
                 }
             }
             writeln!(buffer)?;
@@ -311,9 +336,9 @@ impl<'writer> DefinitionWriter<'writer> {
             let doc = param.doc.as_deref().filter(|d| !d.is_empty());
             result.push(match (param.name.as_deref(), doc) {
                 (Some(name), Some(doc)) => format!("--- @param {name} {ty} {doc}"),
-                (Some(name), None)      => format!("--- @param {name} {ty}"),
-                (None, Some(doc))       => format!("--- @param param{} {ty} {doc}", i + 1),
-                (None, None)            => format!("--- @param param{} {ty}", i + 1),
+                (Some(name), None) => format!("--- @param {name} {ty}"),
+                (None, Some(doc)) => format!("--- @param param{} {ty} {doc}", i + 1),
+                (None, None) => format!("--- @param param{} {ty}", i + 1),
             });
         }
 
@@ -322,23 +347,23 @@ impl<'writer> DefinitionWriter<'writer> {
             let doc = ret.doc.as_deref().filter(|d| !d.is_empty());
             result.push(match doc {
                 Some(doc) => format!("--- @return {ty} #{}: {doc}", i + 1),
-                None      => format!("--- @return {ty}"),
+                None => format!("--- @return {ty}"),
             });
         }
 
         result.push(format!(
-                "{}function{}({}) end",
-                if assign {
-                    format!("{name} = ")
-                } else {
-                    String::new()
-                },
-                if !assign {
-                    format!(" {name}")
-                } else {
-                    String::new()
-                },
-                params
+            "{}function{}({}) end",
+            if assign {
+                format!("{name} = ")
+            } else {
+                String::new()
+            },
+            if !assign {
+                format!(" {name}")
+            } else {
+                String::new()
+            },
+            params
                 .iter()
                 .enumerate()
                 .map(|(i, v)| v
@@ -366,9 +391,9 @@ impl<'writer> DefinitionWriter<'writer> {
             let doc = param.doc.as_deref().filter(|d| !d.is_empty());
             result.push(match (param.name.as_deref(), doc) {
                 (Some(name), Some(doc)) => format!("--- @param {name} {ty} {doc}"),
-                (Some(name), None)      => format!("--- @param {name} {ty}"),
-                (None, Some(doc))       => format!("--- @param param{} {ty} {doc}", i + 1),
-                (None, None)            => format!("--- @param param{} {ty}", i + 1),
+                (Some(name), None) => format!("--- @param {name} {ty}"),
+                (None, Some(doc)) => format!("--- @param param{} {ty} {doc}", i + 1),
+                (None, None) => format!("--- @param param{} {ty}", i + 1),
             });
         }
 
@@ -377,24 +402,24 @@ impl<'writer> DefinitionWriter<'writer> {
             let doc = ret.doc.as_deref().filter(|d| !d.is_empty());
             result.push(match doc {
                 Some(doc) => format!("--- @return {ty} #{}: {doc}", i + 1),
-                None      => format!("--- @return {ty}"),
+                None => format!("--- @return {ty}"),
             });
         }
 
         result.push(format!(
-                "{}function{}({}{}) end",
-                if assign {
-                    format!("{name} = ")
-                } else {
-                    String::new()
-                },
-                if !assign {
-                    format!(" {name}")
-                } else {
-                    String::new()
-                },
-                if params.is_empty() { "self" } else { "self, " },
-                params
+            "{}function{}({}{}) end",
+            if assign {
+                format!("{name} = ")
+            } else {
+                String::new()
+            },
+            if !assign {
+                format!(" {name}")
+            } else {
+                String::new()
+            },
+            if params.is_empty() { "self" } else { "self, " },
+            params
                 .iter()
                 .enumerate()
                 .map(|(i, v)| v
@@ -412,21 +437,29 @@ impl<'writer> DefinitionWriter<'writer> {
         Ok(match ty {
             Type::Enum(_) => match self.name_map.borrow().get(ty) {
                 Some(name) => name.to_string(),
-                None => return Err(mlua::Error::runtime("missing enum type definition; make sure the type is registered before it is used"))
+                None => {
+                    return Err(mlua::Error::runtime(
+                        "missing enum type definition; make sure the type is registered before it is used",
+                    ));
+                }
             },
             Type::Class(_) => match self.name_map.borrow().get(ty) {
                 Some(name) => name.to_string(),
-                None => return Err(mlua::Error::runtime("missing class type definition; make sure the type is registered before it is used"))
+                None => {
+                    return Err(mlua::Error::runtime(
+                        "missing class type definition; make sure the type is registered before it is used",
+                    ));
+                }
             },
             Type::Single(value) => value.to_string(),
             Type::Tuple(types) => {
                 format!(
                     "[{}]",
                     types
-                    .iter()
-                    .map(|v| self.type_signature(v))
-                    .collect::<mlua::Result<Vec<_>>>()?
-                    .join(", ")
+                        .iter()
+                        .map(|v| self.type_signature(v))
+                        .collect::<mlua::Result<Vec<_>>>()?
+                        .join(", ")
                 )
             }
             Type::Array(ty) => {
@@ -443,26 +476,28 @@ impl<'writer> DefinitionWriter<'writer> {
                 format!(
                     "fun({}){}",
                     params
-                    .iter()
-                    .enumerate()
-                    .map(|(i, v)| {
-                        let name = v.name.as_ref()
-                            .map(|n| n.to_string())
-                            .unwrap_or(format!("param{}", i + 1));
-                        Ok(format!("{name}: {}", self.type_signature(&v.ty)?))
-                    })
-                    .collect::<mlua::Result<Vec<_>>>()?
-                    .join(", "),
+                        .iter()
+                        .enumerate()
+                        .map(|(i, v)| {
+                            let name = v
+                                .name
+                                .as_ref()
+                                .map(|n| n.to_string())
+                                .unwrap_or(format!("param{}", i + 1));
+                            Ok(format!("{name}: {}", self.type_signature(&v.ty)?))
+                        })
+                        .collect::<mlua::Result<Vec<_>>>()?
+                        .join(", "),
                     if returns.is_empty() {
                         String::new()
                     } else {
                         format!(
                             ": {}",
                             returns
-                            .iter()
-                            .map(|v| self.type_signature(&v.ty))
-                            .collect::<mlua::Result<Vec<_>>>()?
-                            .join(", ")
+                                .iter()
+                                .map(|v| self.type_signature(&v.ty))
+                                .collect::<mlua::Result<Vec<_>>>()?
+                                .join(", ")
                         )
                     }
                 )
@@ -476,17 +511,17 @@ impl<'writer> DefinitionWriter<'writer> {
                 format!(
                     "{{ {} }}",
                     entries
-                    .iter()
-                    .map(|(k, v)| { Ok(format!("{k}: {}", self.type_signature(v)?)) })
-                    .collect::<mlua::Result<Vec<_>>>()?
-                    .join(", ")
+                        .iter()
+                        .map(|(k, v)| { Ok(format!("{k}: {}", self.type_signature(v)?)) })
+                        .collect::<mlua::Result<Vec<_>>>()?
+                        .join(", ")
                 )
             }
             other => {
                 return Err(mlua::Error::runtime(format!(
-                            "type cannot be a type signature: {}",
-                            other.as_ref()
-                )))
+                    "type cannot be a type signature: {}",
+                    other.as_ref()
+                )));
             }
         })
     }

--- a/src/typed/mod.rs
+++ b/src/typed/mod.rs
@@ -4,15 +4,21 @@ pub mod generator;
 mod class;
 
 pub use class::{
-    TypedClassBuilder, TypedClass, TypedDataDocumentation, TypedDataFields, TypedDataMethods, TypedUserData,
-    WrappedBuilder,
+    TypedClass, TypedClassBuilder, TypedDataDocumentation, TypedDataFields, TypedDataMethods,
+    TypedUserData, WrappedBuilder,
 };
 
 use std::{
-    borrow::Cow, collections::{BTreeMap, BTreeSet, HashMap, HashSet}, marker::PhantomData
+    borrow::Cow,
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    marker::PhantomData,
 };
-#[cfg(feature="userdata-wrappers")]
-use std::{sync::{Arc, Mutex}, cell::{Cell, RefCell}, rc::Rc};
+#[cfg(feature = "userdata-wrappers")]
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+    sync::{Arc, Mutex},
+};
 
 pub use function::{Param, Return, TypedFunction};
 
@@ -691,7 +697,7 @@ where
 
 // External Types
 
-#[cfg(feature="userdata-wrappers")]
+#[cfg(feature = "userdata-wrappers")]
 impl<T: Typed> Typed for Arc<T> {
     fn ty() -> Type {
         T::ty()
@@ -706,7 +712,7 @@ impl<T: Typed> Typed for Arc<T> {
     }
 }
 
-#[cfg(feature="userdata-wrappers")]
+#[cfg(feature = "userdata-wrappers")]
 impl<T: Typed> Typed for Rc<T> {
     fn ty() -> Type {
         T::ty()
@@ -721,7 +727,7 @@ impl<T: Typed> Typed for Rc<T> {
     }
 }
 
-#[cfg(feature="userdata-wrappers")]
+#[cfg(feature = "userdata-wrappers")]
 impl<T: Typed> Typed for Cell<T> {
     fn ty() -> Type {
         T::ty()
@@ -736,7 +742,7 @@ impl<T: Typed> Typed for Cell<T> {
     }
 }
 
-#[cfg(feature="userdata-wrappers")]
+#[cfg(feature = "userdata-wrappers")]
 impl<T: Typed> Typed for RefCell<T> {
     fn ty() -> Type {
         T::ty()
@@ -751,7 +757,7 @@ impl<T: Typed> Typed for RefCell<T> {
     }
 }
 
-#[cfg(feature="userdata-wrappers")]
+#[cfg(feature = "userdata-wrappers")]
 impl<T: Typed> Typed for Mutex<T> {
     fn ty() -> Type {
         T::ty()
@@ -826,11 +832,18 @@ where
     A: Typed,
 {
     fn get_types_as_params() -> Vec<Param> {
-        Vec::from([Param { name: None, doc: None, ty: A::as_param()}])
+        Vec::from([Param {
+            name: None,
+            doc: None,
+            ty: A::as_param(),
+        }])
     }
 
     fn get_types_as_returns() -> Vec<Return> {
-        Vec::from([Return { doc: None, ty: A::as_return() }])
+        Vec::from([Return {
+            doc: None,
+            ty: A::as_return(),
+        }])
     }
 }
 
@@ -883,7 +896,7 @@ impl StaticField {
                 ty,
                 doc: doc.into_doc_comment(),
             },
-            default: default.into()
+            default: default.into(),
         }
     }
 }

--- a/tests/recursive.rs
+++ b/tests/recursive.rs
@@ -64,29 +64,32 @@ impl TypedUserData for TestOption {
                 })
             },
         );
-        
-        #[cfg(feature="userdata-wrappers")]
+
+        #[cfg(feature = "userdata-wrappers")]
         methods.add_function(
             "func_returns_arc_self",
             |_, ()| -> mlua::Result<std::sync::Arc<Self>> { Ok(Default::default()) },
         );
-        #[cfg(feature="userdata-wrappers")]
+        #[cfg(feature = "userdata-wrappers")]
         methods.add_function(
             "func_returns_arc_mutex_self",
-            |_, ()| -> mlua::Result<std::sync::Arc<std::sync::Mutex<Self>>> { Ok(Default::default()) },
+            |_, ()| -> mlua::Result<std::sync::Arc<std::sync::Mutex<Self>>> {
+                Ok(Default::default())
+            },
         );
 
-        #[cfg(feature="userdata-wrappers")]
+        #[cfg(feature = "userdata-wrappers")]
         methods.add_function(
             "func_returns_rc_refcell_self",
             |_, ()| -> mlua::Result<std::rc::Rc<Self>> { Ok(Default::default()) },
         );
-        #[cfg(feature="userdata-wrappers")]
+        #[cfg(feature = "userdata-wrappers")]
         methods.add_function(
             "func_returns_rc_refcell_self",
-            |_, ()| -> mlua::Result<std::rc::Rc<std::cell::RefCell<Self>>> { Ok(Default::default()) },
+            |_, ()| -> mlua::Result<std::rc::Rc<std::cell::RefCell<Self>>> {
+                Ok(Default::default())
+            },
         );
-
 
         methods.add_method("clone", |_, this, ()| Ok(this.clone()));
         methods.add_method(

--- a/tests/typed_user_data.rs
+++ b/tests/typed_user_data.rs
@@ -435,7 +435,10 @@ fn test_static_meta_functions() {
     let result: Vec2 = lua.load("return vec2(1, 2) + vec2(3, 4)").eval().unwrap();
     assert_eq!(result, Vec2(4.0, 6.0));
 
-    let result: f64 = lua.load("return dot(vec2(2, 4), vec2(4, 2))").eval().unwrap();
+    let result: f64 = lua
+        .load("return dot(vec2(2, 4), vec2(4, 2))")
+        .eval()
+        .unwrap();
     assert_eq!(result, 16.0);
 }
 

--- a/tests/user_data.rs
+++ b/tests/user_data.rs
@@ -435,7 +435,10 @@ fn test_static_meta_functions() {
     let result: Vec2 = lua.load("return vec2(1, 2) + vec2(3, 4)").eval().unwrap();
     assert_eq!(result, Vec2(4.0, 6.0));
 
-    let result: f64 = lua.load("return dot(vec2(2, 4), vec2(4, 2))").eval().unwrap();
+    let result: f64 = lua
+        .load("return dot(vec2(2, 4), vec2(4, 2))")
+        .eval()
+        .unwrap();
     assert_eq!(result, 16.0);
 }
 


### PR DESCRIPTION
Noticed that a lot of reformatting would happen when I had `format_on_save` enabled in my editor. My suggestion would be to run `cargo fmt --check` as part of the pipeline.