### PR TITLE
Update LICENSE comments for userdata macros

### DIFF
--- a/mlua_extras_derive/src/userdata/mod.rs
+++ b/mlua_extras_derive/src/userdata/mod.rs
@@ -1,3 +1,34 @@
+//! Both mlua and rlua are distributed under the MIT license, which is reproduced
+//! below:
+//! 
+//! MIT License
+//! 
+//! Copyright (c) 2019-2021 A. Orlenko
+//! Copyright (c) 2017 rlua
+//! 
+//! Permission is hereby granted, free of charge, to any person obtaining a copy
+//! of this software and associated documentation files (the "Software"), to deal
+//! in the Software without restriction, including without limitation the rights
+//! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//! copies of the Software, and to permit persons to whom the Software is
+//! furnished to do so, subject to the following conditions:
+//! 
+//! The above copyright notice and this permission notice shall be included in all
+//! copies or substantial portions of the Software.
+//! 
+//! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//! SOFTWARE.
+//!
+//! The above notice applies to this file's code as a large portion is copied from, or closely replicates `mlua` to provide
+//! a similar experience while giving additional type information to `mlua_extras` typing system.
+//! 
+//! https://github.com/mlua-rs/mlua/blob/main/mlua_derive/src/userdata/mod.rshttps://github.com/mlua-rs
+
 use proc_macro2::TokenStream;
 use syn::{Attribute, Data, DeriveInput, Error, Fields, FieldsNamed, Meta};
 

--- a/mlua_extras_derive/src/userdata/userdata_impl.rs
+++ b/mlua_extras_derive/src/userdata/userdata_impl.rs
@@ -1,3 +1,34 @@
+//! Both mlua and rlua are distributed under the MIT license, which is reproduced
+//! below:
+//! 
+//! MIT License
+//! 
+//! Copyright (c) 2019-2021 A. Orlenko
+//! Copyright (c) 2017 rlua
+//! 
+//! Permission is hereby granted, free of charge, to any person obtaining a copy
+//! of this software and associated documentation files (the "Software"), to deal
+//! in the Software without restriction, including without limitation the rights
+//! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//! copies of the Software, and to permit persons to whom the Software is
+//! furnished to do so, subject to the following conditions:
+//! 
+//! The above copyright notice and this permission notice shall be included in all
+//! copies or substantial portions of the Software.
+//! 
+//! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//! SOFTWARE.
+//!
+//! The above notice applies to this file's code as a large portion is copied from, or closely replicates `mlua` to provide
+//! a similar experience while giving additional type information to `mlua_extras` typing system.
+//! 
+//! https://github.com/mlua-rs/mlua/blob/main/mlua_derive/src/userdata/userdata_impl.rs
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use proc_macro2::{Span, TokenStream};


### PR DESCRIPTION
[fix] add LICENSE comments to userdata macros referencing mlua