### PR TITLE
derive Clone Debug and PartialEq for TypedFunction

### DIFF
--- a/src/typed/function.rs
+++ b/src/typed/function.rs
@@ -148,6 +148,7 @@ where
 /// Helper to bake the type information for a lua [`Function`][mlua::Function]. This makes repeated
 /// calls to the [`Function`][mlua::Function]'s [`call`][mlua::Function::call] all the same with
 /// enforced arguments and return types.
+#[derive(Clone, Debug, PartialEq)]
 pub struct TypedFunction<Params, Response>
 where
     Params: TypedMultiValue,


### PR DESCRIPTION
mlua::Function implements Clone Debug and PartialEq, it would make sense for TypedFunction to implement these as well